### PR TITLE
Increase the maxAge and introduce versioning

### DIFF
--- a/.changeset/@theguild_components-649-dependencies.md
+++ b/.changeset/@theguild_components-649-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@theguild/components": patch
+---
+dependencies updates:
+  - Updated dependency [`@next/bundle-analyzer@13.0.6` ↗︎](https://www.npmjs.com/package/@next/bundle-analyzer/v/13.0.6) (from `13.0.5`, in `dependencies`)
+  - Updated dependency [`next@^12.3.1 || ^13.0.0` ↗︎](https://www.npmjs.com/package/next/v/12.3.1) (from `^12.3.1`, in `peerDependencies`)

--- a/packages/open-graph-image/src/index.tsx
+++ b/packages/open-graph-image/src/index.tsx
@@ -76,14 +76,14 @@ const day = hour * 24;
 const year = 365 * day;
 
 const maxAgeForCDN = year;
-const maxAgeForBrowser = hour/2;
+const maxAgeForBrowser = hour / 2;
 
 export default {
   async fetch(request: Request, _env: unknown, ctx: ExecutionContext) {
     const cacheUrl = new URL(request.url);
 
     // In case you want to purge the cache, please bump the version number below:
-    cacheUrl.searchParams.set('version', "v1");
+    cacheUrl.searchParams.set('version', 'v1');
 
     // Construct the cache key from the cache URL
     const cacheKey = new Request(cacheUrl.toString(), request);

--- a/packages/open-graph-image/src/index.tsx
+++ b/packages/open-graph-image/src/index.tsx
@@ -71,9 +71,19 @@ async function handler(request: Request): Promise<Response> {
   }
 }
 
+const hour = 3600;
+const day = hour * 24;
+const year = 365 * day;
+
+const maxAgeForCDN = year;
+const maxAgeForBrowser = hour/2;
+
 export default {
   async fetch(request: Request, _env: unknown, ctx: ExecutionContext) {
     const cacheUrl = new URL(request.url);
+
+    // In case you want to purge the cache, please bump the version number below:
+    cacheUrl.searchParams.set('version', "v1");
 
     // Construct the cache key from the cache URL
     const cacheKey = new Request(cacheUrl.toString(), request);
@@ -88,13 +98,10 @@ export default {
       // Must use Response constructor to inherit all of response's fields
       response = new Response(response.body, response);
 
-      // Cache API respects Cache-Control headers. Setting s-max-age to 10
-      // will limit the response to be in cache for 30 minutes max
-
       // Any changes made to the response here will be reflected in the cached value
       response.headers.append('Cache-Control', 'public');
-      response.headers.append('Cache-Control', 's-maxage=1800');
-      response.headers.append('Cache-Control', 'max-age=1800');
+      response.headers.append('Cache-Control', `s-maxage=${maxAgeForCDN}`);
+      response.headers.append('Cache-Control', `max-age=${maxAgeForBrowser}`);
 
       // Store the fetched response as cacheKey
       // Use `waitUntil`, so you can return the response without blocking on


### PR DESCRIPTION
Browser will cache the resource for 30 minutes.
Cloudflare CDN will cache the resource for a year.

This way the browser's cache will mark the resource as stale after 30 minutes, but the "new" resource will be shipped by Cloudflare from the cache.

In case we want to purge the cache (because of changes in styling etc), we will have to bump the version number.

It could be done in a better way with `Vary`, `Stale-While-Revalidate`, `If-None-Match` and `ETag` based on an image's checksum, but I'm too lazy and it's not that important right now...