### PR TITLE
Missing  language attribute + Open graph type for all website pages

### DIFF
--- a/.changeset/@theguild_components-1019-dependencies.md
+++ b/.changeset/@theguild_components-1019-dependencies.md
@@ -1,0 +1,9 @@
+---
+"@theguild/components": patch
+---
+dependencies updates:
+  - Updated dependency [`@next/bundle-analyzer@13.4.2` ↗︎](https://www.npmjs.com/package/@next/bundle-analyzer/v/13.4.2) (from `13.3.4`, in `dependencies`)
+  - Updated dependency [`focus-trap-react@10.1.4` ↗︎](https://www.npmjs.com/package/focus-trap-react/v/10.1.4) (from `10.1.1`, in `dependencies`)
+  - Updated dependency [`nextra@2.5.2` ↗︎](https://www.npmjs.com/package/nextra/v/2.5.2) (from `2.5.0`, in `dependencies`)
+  - Updated dependency [`nextra-theme-docs@2.5.2` ↗︎](https://www.npmjs.com/package/nextra-theme-docs/v/2.5.2) (from `2.5.0`, in `dependencies`)
+  - Updated dependency [`react-instantsearch-dom@6.40.0` ↗︎](https://www.npmjs.com/package/react-instantsearch-dom/v/6.40.0) (from `6.39.1`, in `dependencies`)

--- a/.changeset/curly-beds-run.md
+++ b/.changeset/curly-beds-run.md
@@ -2,5 +2,4 @@
 '@theguild/components': patch
 ---
 
-Added open graph type to website pages. By default type is 'website'. And, added to head missing
-attribute lang=en
+Added open graph type to website pages. By default type is 'website'

--- a/.changeset/curly-beds-run.md
+++ b/.changeset/curly-beds-run.md
@@ -1,0 +1,6 @@
+---
+'@theguild/components': patch
+---
+
+Added open graph type to website pages. By default type is 'website'. And, added to head missing
+attribute lang=en

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -71,6 +71,8 @@ export function defineConfig({
       const { frontMatter, title } = useConfig();
       const { asPath } = useRouter();
       const nextSeoProps = config.useNextSeoProps?.();
+      const type = frontMatter.type || 'website';
+
       return {
         titleTemplate: `%s – ${siteName}`,
         description: frontMatter.description || `${siteName} Documentation`,
@@ -81,6 +83,7 @@ export function defineConfig({
         },
         canonical: frontMatter.canonical || (siteUrl && `${siteUrl}${asPath}`),
         openGraph: {
+          type: type.toLowerCase(),
           siteName,
           images: [
             {

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -71,7 +71,7 @@ export function defineConfig({
       const { frontMatter, title } = useConfig();
       const { asPath } = useRouter();
       const nextSeoProps = config.useNextSeoProps?.();
-      const type = frontMatter.type || 'website';
+      const type = frontMatter.type ?? 'website';
 
       return {
         titleTemplate: `%s – ${siteName}`,

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -52,7 +52,7 @@ export function defineConfig({
     project: {
       link: `${url.origin}/${org}/${repoName}`, // GitHub link in the navbar
     },
-    head: null,
+    head: <html lang="en" />,
     logo: product?.logo && (
       <>
         <product.logo className="mr-1.5 h-9 w-9" />

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -52,7 +52,7 @@ export function defineConfig({
     project: {
       link: `${url.origin}/${org}/${repoName}`, // GitHub link in the navbar
     },
-    head: <html lang="en" />,
+    head: null,
     logo: product?.logo && (
       <>
         <product.logo className="mr-1.5 h-9 w-9" />
@@ -71,7 +71,7 @@ export function defineConfig({
       const { frontMatter, title } = useConfig();
       const { asPath } = useRouter();
       const nextSeoProps = config.useNextSeoProps?.();
-      const type = frontMatter.type ?? 'website';
+      const type = frontMatter.type?.toLowerCase() ?? 'website';
 
       return {
         titleTemplate: `%s – ${siteName}`,
@@ -83,7 +83,7 @@ export function defineConfig({
         },
         canonical: frontMatter.canonical || (siteUrl && `${siteUrl}${asPath}`),
         openGraph: {
-          type: type.toLowerCase(),
+          type,
           siteName,
           images: [
             {


### PR DESCRIPTION
We need to add `og:type` for all our website pages - because we have over 1000 warnings about it from Ahrefs and Google search console.