### PR TITLE
fix: no trailing slash on homepages

### DIFF
--- a/.changeset/great-baboons-switch.md
+++ b/.changeset/great-baboons-switch.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+No trailing slash on homepages

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -79,7 +79,21 @@ export function defineConfig({
           site: 'https://the-guild.dev',
           handle: '@TheGuildDev',
         },
-        canonical: frontMatter.canonical || (siteUrl && `${siteUrl}${asPath}`),
+        canonical:
+          frontMatter.canonical ||
+          (siteUrl &&
+            `${siteUrl}${
+              // we disallow trailing slashes
+              // TODO: dont do this if `trailingSlashes: true`
+              asPath === '/'
+                ? // homepage
+                  ''
+                : asPath.startsWith('/?')
+                ? // homepage with search params (remove just slash)
+                  asPath.slice(1)
+                : // other pages
+                  asPath
+            }`),
         openGraph: {
           siteName,
           images: [


### PR DESCRIPTION
The canonical SEO prop contained URLs with a trailing forward slash, while the server strips them.

This leads to a redirect cycle:
1. Input URL -> https://the-guild.dev/graphql/yoga-server
1. og:url Meta Tag -> https://the-guild.dev/graphql/yoga-server/
1. 301 HTTP Redirect -> https://the-guild.dev/graphql/yoga-server
1. og:url Meta Tag ->	https://the-guild.dev/graphql/yoga-server/