### PR TITLE
Run CI and publish snaphots on PRs to all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+  # eslint-disable-next-line yml/no-empty-mapping-value
   pull_request:
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,8 +2,6 @@ name: PR
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   dependencies:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,7 @@
 name: PR
 
 on:
+  # eslint-disable-next-line yml/no-empty-mapping-value
   pull_request:
 
 jobs:


### PR DESCRIPTION
@saihaj noticed the snaphots weren't published from my branches.
I looked into it quickly, and it turns out it's because I pointed them to Dima's `v7` branch.

Seems we should either stick to just a `main-featureBranch` workflow or remove the `branches` includelist from `pull_request` trigger so it runs on all PRs.