### PR TITLE
Prevent scrolling to headings on click

### DIFF
--- a/.changeset/wet-bugs-shout.md
+++ b/.changeset/wet-bugs-shout.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Prevent scrolling to headings on click

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,7 @@ module.exports = {
   },
   settings: {
     tailwindcss: {
+      callees: ['clsx', 'cn', 'cva', 'cx'],
       config: 'tailwind.config.ts',
       whitelist: [
         // TODO: find a way to fix it and remove these classes since they are imported somewhere and are used

--- a/packages/components/src/components/cookies-consent.stories.tsx
+++ b/packages/components/src/components/cookies-consent.stories.tsx
@@ -8,8 +8,6 @@ export default {
   component: CookiesConsent,
   decorators: [
     Story => {
-      // false positives on unused variables
-      // eslint-disable-next-line react/hook-use-state
       const [key, setKey] = useState(0);
       const remount = () => setKey(Math.random());
 

--- a/packages/components/src/components/cookies-consent.tsx
+++ b/packages/components/src/components/cookies-consent.tsx
@@ -19,7 +19,7 @@ export function CookiesConsent(props: CookiesConsentProps) {
     <div
       {...props}
       className={cn(
-        'z-100 fixed bottom-0 flex flex-wrap items-center justify-center gap-x-4 gap-y-3 rounded-lg border border-beige-200 bg-beige-100 p-4 text-sm text-green-800 shadow-xl lg:flex-nowrap lg:justify-between lg:text-left dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200',
+        'fixed bottom-0 z-50 flex flex-wrap items-center justify-center gap-x-4 gap-y-3 rounded-lg border border-beige-200 bg-beige-100 p-4 text-sm text-green-800 shadow-xl lg:flex-nowrap lg:justify-between lg:text-left dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200',
         props.className,
       )}
     >

--- a/packages/components/src/components/decorations.tsx
+++ b/packages/components/src/components/decorations.tsx
@@ -70,6 +70,7 @@ export function HighlightDecoration(props: React.SVGAttributes<SVGSVGElement>) {
       viewBox="0 0 895 674"
       fill="#86B6C1"
       {...props}
+      // eslint-disable-next-line tailwindcss/no-custom-classname
       className={cn('firefox-highlight-fix', props.className)}
     >
       <g filter="url(#filter0_f_711_1774)">

--- a/packages/components/src/components/heading.stories.tsx
+++ b/packages/components/src/components/heading.stories.tsx
@@ -31,3 +31,26 @@ export const Heading: StoryObj<HeadingProps> = {
     size: 'xl',
   },
 };
+
+export const NoScrollingOnClick: StoryObj<HeadingProps> = {
+  args: { as: 'h2', size: 'lg' },
+  decorators: [
+    Story => (
+      <div className="relative h-[150vh]">
+        <div className="absolute top-1/2">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  play(ctx) {
+    const anchor = ctx.canvasElement.querySelector('a')!;
+    anchor.click();
+    if (window.location.hash !== '#open-source-graphql-management-platform') {
+      throw new Error('Expected hash to be set');
+    }
+    if (window.scrollY !== 0) {
+      throw new Error('Expected scroll to be at top');
+    }
+  },
+};

--- a/packages/components/src/components/heading.tsx
+++ b/packages/components/src/components/heading.tsx
@@ -32,7 +32,7 @@ export function Heading({ as: _as, size, className, children, ...rest }: Heading
   return (
     <Level className={cn(sizeStyle, className)} id={id} {...rest}>
       {id ? (
-        <a href={`#${id}`} className="cursor-text" tabIndex={-1}>
+        <a href={`#${id}`} className="cursor-text" tabIndex={-1} onClick={preventScroll}>
           {children}
         </a>
       ) : (
@@ -40,4 +40,14 @@ export function Heading({ as: _as, size, className, children, ...rest }: Heading
       )}
     </Level>
   );
+}
+
+function preventScroll(event: React.MouseEvent<HTMLAnchorElement>) {
+  if (event.currentTarget.tagName !== 'A') return;
+  const href = event.currentTarget.getAttribute('href');
+  if (href?.[0] !== '#') return;
+  event.preventDefault();
+  const url = new URL(window.location.href);
+  url.hash = href.slice(1);
+  window.history.replaceState({}, '', url.toString());
 }

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -30,3 +30,4 @@ export { ToolsAndLibrariesCards } from './tools-and-libraries-cards';
 export * from './decorations';
 export * from './call-to-action';
 export * from './cookies-consent';
+export * from './heading';


### PR DESCRIPTION
We navigate, so the user can copy a link, but we don't scroll anymore.
per @kamilkisiela's comment