### PR TITLE
Navigation polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  # eslint-disable-next-line yml/no-empty-mapping-value
-  pull_request:
+  pull_request: {}
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,7 @@
 name: PR
 
 on:
-  # eslint-disable-next-line yml/no-empty-mapping-value
-  pull_request:
+  pull_request: {}
 
 jobs:
   dependencies:

--- a/packages/components/src/components/cookies-consent.tsx
+++ b/packages/components/src/components/cookies-consent.tsx
@@ -33,6 +33,8 @@ export function CookiesConsent(props: CookiesConsentProps) {
         <a
           href="https://the-guild.dev/graphql/hive/privacy-policy.pdf"
           className="whitespace-nowrap hover:text-blue-700 hover:underline dark:hover:text-blue-100"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Privacy Policy
         </a>

--- a/packages/components/src/components/hive-navigation/hive-navigation.stories.tsx
+++ b/packages/components/src/components/hive-navigation/hive-navigation.stories.tsx
@@ -25,7 +25,6 @@ export default {
   decorators: [hiveThemeDecorator, nextraThemeDocsCtxDecorator],
   args: {
     productName: 'Hive',
-    items: [{ name: 'Mobile Item 1', title: 'Mobile Item 1', route: '/', items: {}, type: 'link' }],
   },
 } as Meta<HiveNavigationProps>;
 
@@ -52,7 +51,27 @@ export const ForcedLightMode: StoryObj = {
   ...Default,
   decorators: [
     Story => (
-      <div className="light">
+      <div className="light" style={{ '--nextra-bg': '255 255 255' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const BackgroundFromCSSProperty: StoryObj = {
+  ...Default,
+  decorators: [
+    Story => (
+      // eslint-disable-next-line tailwindcss/no-custom-classname
+      <div className="background-vars">
+        <style>{`
+          .background-vars {
+            --nextra-bg: 250 250 250;
+          }
+          .dark .background-vars {
+            --nextra-bg: 30 30 30;
+          }
+        `}</style>
         <Story />
       </div>
     ),
@@ -67,7 +86,7 @@ export const Viewport: StoryObj = {
           <NavigationMenuItem>
             <NavigationMenuTrigger>Menu Item</NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ProductsMenu />
+              <ProductsMenu isHive={false} />
             </NavigationMenuContent>
           </NavigationMenuItem>
         </NavigationMenuList>
@@ -83,7 +102,7 @@ export const Products: StoryObj = {
   render() {
     return (
       <NavigationMenu>
-        <ProductsMenu />
+        <ProductsMenu isHive={false} />
       </NavigationMenu>
     );
   },

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, Fragment, ReactNode } from 'react';
+import { useRouter } from 'next/router';
 import { useMenu, useThemeConfig } from 'nextra-theme-docs';
 import { MenuIcon } from 'nextra/icons';
 import { cn } from '../../cn';
@@ -90,7 +91,7 @@ export function HiveNavigation({
           <NavigationMenuItem>
             <NavigationMenuTrigger>Products</NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ProductsMenu />
+              <ProductsMenu isHive={isHive} />
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem>
@@ -156,105 +157,123 @@ export function HiveNavigation({
   );
 }
 
+interface ProductsMenuProps extends MenuContentColumnsProps {
+  isHive: boolean;
+}
 /**
  * @internal
  */
-export const ProductsMenu = React.forwardRef<HTMLDivElement, object>((props, ref) => {
-  return (
-    <MenuContentColumns ref={ref} {...props}>
-      <div className="w-[220px]">
-        <ColumnLabel>Platform</ColumnLabel>
-        <NavigationMenuLink href={PRODUCTS.HIVE.href} className="p-4">
-          <div className="w-fit rounded-lg bg-green-800 p-3 dark:bg-white/10">
-            <HiveIcon className="size-10 text-white" />
-          </div>
-          <p className="mt-4 text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
-            Hive
-          </p>
-          <p className="mt-1 text-sm leading-5 text-green-800 dark:text-neutral-400">
-            GraphQL Management Platform & Decision-making Engine
-          </p>
-        </NavigationMenuLink>
-        <Anchor
-          href="https://app.graphql-hive.com/"
-          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
-        >
-          <span>Get started</span> <ArrowIcon />
-        </Anchor>
-      </div>
-      <div className="w-[257px]">
-        <ColumnLabel>The GraphQL Stack</ColumnLabel>
-        <ul>
-          {(
-            [
-              [PRODUCTS.MESH, 'Gateway GraphQL API'],
-              [PRODUCTS.YOGA, 'GraphQL Subgraph'],
-              [PRODUCTS.CODEGEN, 'GraphQL Code Generation'],
-            ] as const
-          ).map(([product, description]) => {
-            const Logo = product.logo;
-            return (
-              <li key={product.name}>
-                <NavigationMenuLink
-                  href={product.href}
-                  className="flex flex-row items-center gap-4 p-4"
-                >
-                  <div className="size-12 rounded-lg bg-blue-400 p-2.5">
-                    <Logo className="size-7 text-green-1000" />
-                  </div>
-                  <div>
-                    <p className="text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
-                      {product.name}
-                    </p>
-                    <p className="col-start-2 mt-1 text-sm leading-5 text-green-800 dark:text-neutral-300">
-                      {description}
-                    </p>
-                  </div>
-                </NavigationMenuLink>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-      <div className="w-[364px]">
-        <ColumnLabel>Libraries</ColumnLabel>
-        <ul className="grid grid-cols-2 gap-x-4">
-          {SIX_HIGHLIGHTED_PRODUCTS.map(product => {
-            const Logo = product.logo;
-            return (
-              <li key={product.name}>
-                <NavigationMenuLink
-                  href={product.href}
-                  className="flex flex-row items-center gap-3 px-4 py-2"
-                  arrow
-                >
-                  <div className="flex size-8 items-center justify-center rounded bg-beige-200 dark:bg-white/5">
-                    <Logo className="size-8 text-green-1000 dark:text-neutral-300" />
-                  </div>
-                  <div>
-                    <p className="text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
-                      {product.name}
-                    </p>
-                  </div>
-                </NavigationMenuLink>
-              </li>
-            );
-          })}
-        </ul>
-        <Anchor
-          href={EXPLORE_HREF}
-          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
-        >
-          <span>Explore all libraries</span> <ArrowIcon />
-        </Anchor>
-      </div>
-    </MenuContentColumns>
-  );
-});
+export const ProductsMenu = React.forwardRef<HTMLDivElement, ProductsMenuProps>(
+  ({ isHive, ...rest }, ref) => {
+    const { asPath } = useRouter();
+
+    return (
+      <MenuContentColumns ref={ref} {...rest}>
+        <div className="w-[220px]">
+          <ColumnLabel>Platform</ColumnLabel>
+          <NavigationMenuLink
+            href={
+              isHive
+                ? // We link bidirectionally between the landing page and the docs.
+                  asPath === '/'
+                  ? '/docs'
+                  : '/'
+                : PRODUCTS.HIVE.href
+            }
+            className="p-4"
+          >
+            <div className="w-fit rounded-lg bg-green-800 p-3 dark:bg-white/10">
+              <HiveIcon className="size-10 text-white" />
+            </div>
+            <p className="mt-4 text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
+              Hive
+            </p>
+            <p className="mt-1 text-sm leading-5 text-green-800 dark:text-neutral-400">
+              GraphQL Management Platform & Decision-making Engine
+            </p>
+          </NavigationMenuLink>
+          <Anchor
+            href="https://app.graphql-hive.com/"
+            className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
+          >
+            <span>Get started</span> <ArrowIcon />
+          </Anchor>
+        </div>
+        <div className="w-[257px]">
+          <ColumnLabel>The GraphQL Stack</ColumnLabel>
+          <ul>
+            {(
+              [
+                [PRODUCTS.MESH, 'Gateway GraphQL API'],
+                [PRODUCTS.YOGA, 'GraphQL Subgraph'],
+                [PRODUCTS.CODEGEN, 'GraphQL Code Generation'],
+              ] as const
+            ).map(([product, description]) => {
+              const Logo = product.logo;
+              return (
+                <li key={product.name}>
+                  <NavigationMenuLink
+                    href={product.href}
+                    className="flex flex-row items-center gap-4 p-4"
+                  >
+                    <div className="size-12 rounded-lg bg-blue-400 p-2.5">
+                      <Logo className="size-7 text-green-1000" />
+                    </div>
+                    <div>
+                      <p className="text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
+                        {product.name}
+                      </p>
+                      <p className="col-start-2 mt-1 text-sm leading-5 text-green-800 dark:text-neutral-300">
+                        {description}
+                      </p>
+                    </div>
+                  </NavigationMenuLink>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <div className="w-[364px]">
+          <ColumnLabel>Libraries</ColumnLabel>
+          <ul className="grid grid-cols-2 gap-x-4">
+            {SIX_HIGHLIGHTED_PRODUCTS.map(product => {
+              const Logo = product.logo;
+              return (
+                <li key={product.name}>
+                  <NavigationMenuLink
+                    href={product.href}
+                    className="flex flex-row items-center gap-3 px-4 py-2"
+                    arrow
+                  >
+                    <div className="flex size-8 items-center justify-center rounded bg-beige-200 dark:bg-white/5">
+                      <Logo className="size-8 text-green-1000 dark:text-neutral-300" />
+                    </div>
+                    <div>
+                      <p className="text-base font-medium leading-normal text-green-1000 dark:text-neutral-200">
+                        {product.name}
+                      </p>
+                    </div>
+                  </NavigationMenuLink>
+                </li>
+              );
+            })}
+          </ul>
+          <Anchor
+            href={EXPLORE_HREF}
+            className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
+          >
+            <span>Explore all libraries</span> <ArrowIcon />
+          </Anchor>
+        </div>
+      </MenuContentColumns>
+    );
+  },
+);
 ProductsMenu.displayName = 'ProductsMenu';
 
+interface MenuContentColumnsProps extends React.HTMLAttributes<HTMLDivElement> {}
 const MenuContentColumns = forwardRef(
-  (props: React.HTMLAttributes<HTMLDivElement>, ref: React.ForwardedRef<HTMLDivElement>) => {
+  (props: MenuContentColumnsProps, ref: React.ForwardedRef<HTMLDivElement>) => {
     return (
       <div className="flex gap-x-6 [&>*]:flex [&>*]:flex-col [&>*]:gap-4" ref={ref} {...props}>
         {React.Children.toArray(props.children)

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -177,7 +177,7 @@ export const ProductsMenu = React.forwardRef<HTMLDivElement, object>((props, ref
         </NavigationMenuLink>
         <Anchor
           href="https://app.graphql-hive.com/"
-          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:text-green-1000 dark:text-neutral-400 dark:hover:text-neutral-200"
+          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
         >
           <span>Get started</span> <ArrowIcon />
         </Anchor>
@@ -243,7 +243,7 @@ export const ProductsMenu = React.forwardRef<HTMLDivElement, object>((props, ref
         </ul>
         <Anchor
           href={EXPLORE_HREF}
-          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:text-green-1000 dark:text-neutral-400 dark:hover:text-neutral-200"
+          className="-my-2 ml-2 flex items-center gap-2 rounded-lg p-2 font-medium text-green-800 transition-colors hover:bg-beige-100 hover:text-green-1000 dark:text-neutral-400 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-200"
         >
           <span>Explore all libraries</span> <ArrowIcon />
         </Anchor>

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -74,7 +74,7 @@ export function HiveNavigation({
   return (
     <div
       className={cn(
-        'sticky top-0 z-20 bg-white px-6 py-4 text-green-1000 md:my-2 dark:bg-[rgb(var(--nextra-bg))] dark:text-neutral-200 [&.light]:bg-white [&.light]:text-green-1000',
+        'sticky top-0 z-20 bg-[rgb(var(--nextra-bg))] px-6 py-4 text-green-1000 md:my-2 dark:text-neutral-200 [&.light]:bg-white [&.light]:text-green-1000',
         className?.includes('light') && 'light',
       )}
     >
@@ -87,7 +87,7 @@ export function HiveNavigation({
       {/* desktop menu */}
       <NavigationMenu className={cn('mx-auto hidden md:flex', className)} delayDuration={0}>
         <HiveLogoLink />
-        <NavigationMenuList className="lg:ml-16">
+        <NavigationMenuList className="bg-white lg:ml-16 dark:bg-transparent">
           <NavigationMenuItem>
             <NavigationMenuTrigger>Products</NavigationMenuTrigger>
             <NavigationMenuContent>
@@ -130,7 +130,7 @@ export function HiveNavigation({
         {renderSlot(Search, {
           // The && and :is(x) selector bump the specificity to 0-2-2 to override Nextra styles.
           className: cn(
-            'relative ml-4 [&&_input:is(input)]:h-[48px] [&&_input:is(input)]:rounded-lg [&&_input:is(input)]:border-green-200 [&&_input:is(input)]:bg-inherit [&&_input:is(input)]:pl-4 [&&_input:is(input)]:pr-8 [&&_kbd:is(kbd)]:absolute [&&_kbd:is(kbd)]:right-4 [&&_kbd:is(kbd)]:top-1/2 [&&_kbd:is(kbd)]:translate-y-[-50%] [&&_kbd:is(kbd)]:border-none [&&_kbd:is(kbd)]:bg-green-200 [&&_input:is(input)]:border dark:[&&_input:is(input)]:border-neutral-800 dark:[&&_kbd:is(kbd)]:bg-neutral-700 [&&_:is(input,kbd):is(input,kbd)]:text-green-700 dark:[&&_:is(input,kbd):is(input,kbd)]:text-neutral-300 [&&_kbd:is(kbd)]:my-0',
+            'relative ml-4 [&&_input:is(input)]:h-[48px] [&&_input:is(input)]:bg-white [&&_input:is(input)]:dark:bg-inherit [&&_input:is(input)]:rounded-lg [&&_input:is(input)]:border-green-200 [&&_input:is(input)]:pl-4 [&&_input:is(input)]:pr-8 [&&_kbd:is(kbd)]:absolute [&&_kbd:is(kbd)]:right-4 [&&_kbd:is(kbd)]:top-1/2 [&&_kbd:is(kbd)]:translate-y-[-50%] [&&_kbd:is(kbd)]:border-none [&&_kbd:is(kbd)]:bg-green-200 [&&_input:is(input)]:border dark:[&&_input:is(input)]:border-neutral-800 dark:[&&_kbd:is(kbd)]:bg-neutral-700 [&&_:is(input,kbd):is(input,kbd)]:text-green-700 dark:[&&_:is(input,kbd):is(input,kbd)]:text-neutral-300 [&&_kbd:is(kbd)]:my-0',
           ),
         })}
 


### PR DESCRIPTION
Tweaking stuff around the navigation.

- Made the big Hive tile link two-way between /docs and landing as @saihaj proposed (I can't find that message on Slack) to make it more useful and not a dead click that links to the page we're already on.
- We also use `--nextra-bg` for background to match the docs (can't be transparent as it's sticky).

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/6c52eb16-4f5b-4afa-b5f9-aa8f2a74ec6a">
