### PR TITLE
Export `cn` function from @theguild/components

### DIFF
--- a/.changeset/real-balloons-play.md
+++ b/.changeset/real-balloons-play.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Export `cn` function from @theguild/components

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -32,6 +32,7 @@ export { fetchPackageInfo } from './npm';
 export { PRODUCTS } from './products';
 export * from './types/components';
 export * from './logos';
+export * from './cn';
 
 declare module 'react' {
   interface CSSProperties {


### PR DESCRIPTION
The websites don't need to define this function, as this copy already lands in their bundles.