### PR TITLE
Generalize the bidirectional link idea to all products

### DIFF
--- a/.changeset/grumpy-starfishes-crash.md
+++ b/.changeset/grumpy-starfishes-crash.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+Generalize bidirectional navmenu links to all products

--- a/.changeset/real-balloons-play.md
+++ b/.changeset/real-balloons-play.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Export `cn` function from @theguild/components

--- a/packages/components/src/components/hive-navigation/hive-navigation.stories.tsx
+++ b/packages/components/src/components/hive-navigation/hive-navigation.stories.tsx
@@ -1,6 +1,7 @@
 import { DocsThemeConfig, default as NextraLayout } from 'nextra-theme-docs';
 import { Meta, StoryContext, StoryObj } from '@storybook/react';
 import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
+import { PRODUCTS } from '../../products';
 import { GraphQLConfCard } from './graphql-conf-card';
 import {
   CompanyMenu,
@@ -86,7 +87,7 @@ export const Viewport: StoryObj = {
           <NavigationMenuItem>
             <NavigationMenuTrigger>Menu Item</NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ProductsMenu isHive={false} />
+              <ProductsMenu productName={PRODUCTS.CODEGEN.name} />
             </NavigationMenuContent>
           </NavigationMenuItem>
         </NavigationMenuList>
@@ -102,7 +103,7 @@ export const Products: StoryObj = {
   render() {
     return (
       <NavigationMenu>
-        <ProductsMenu isHive={false} />
+        <ProductsMenu productName={PRODUCTS.YOGA.name} />
       </NavigationMenu>
     );
   },

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -104,7 +104,7 @@ export function HiveNavigation({
           <NavigationMenuItem>
             <NavigationMenuTrigger>Products</NavigationMenuTrigger>
             <NavigationMenuContent>
-              <ProductsMenu isHive={isHive} />
+              <ProductsMenu productName={productName} />
             </NavigationMenuContent>
           </NavigationMenuItem>
           <NavigationMenuItem>
@@ -168,30 +168,28 @@ export function HiveNavigation({
 }
 
 interface ProductsMenuProps extends MenuContentColumnsProps {
-  isHive: boolean;
+  productName: string;
 }
 /**
  * @internal
  */
 export const ProductsMenu = React.forwardRef<HTMLDivElement, ProductsMenuProps>(
-  ({ isHive, ...rest }, ref) => {
+  ({ productName, ...rest }, ref) => {
     const { asPath } = useRouter();
+
+    const bidirectionalProductLink = (product: (typeof PRODUCTS)[keyof typeof PRODUCTS]) => {
+      if (productName === product.name) {
+        // We link bidirectionally between the landing page and the docs.
+        return asPath === '/' ? '/docs' : '/';
+      }
+      return product.href;
+    };
 
     return (
       <MenuContentColumns ref={ref} {...rest}>
         <div className="w-[220px]">
           <ColumnLabel>Platform</ColumnLabel>
-          <NavigationMenuLink
-            href={
-              isHive
-                ? // We link bidirectionally between the landing page and the docs.
-                  asPath === '/'
-                  ? '/docs'
-                  : '/'
-                : PRODUCTS.HIVE.href
-            }
-            className="p-4"
-          >
+          <NavigationMenuLink href={bidirectionalProductLink(PRODUCTS.HIVE)} className="p-4">
             <div className="w-fit rounded-lg bg-green-800 p-3 dark:bg-white/10">
               <HiveIcon className="size-10 text-white" />
             </div>
@@ -223,7 +221,7 @@ export const ProductsMenu = React.forwardRef<HTMLDivElement, ProductsMenuProps>(
               return (
                 <li key={product.name}>
                   <NavigationMenuLink
-                    href={product.href}
+                    href={bidirectionalProductLink(product)}
                     className="flex flex-row items-center gap-4 p-4"
                   >
                     <div className="size-12 rounded-lg bg-blue-400 p-2.5">
@@ -251,7 +249,7 @@ export const ProductsMenu = React.forwardRef<HTMLDivElement, ProductsMenuProps>(
               return (
                 <li key={product.name}>
                   <NavigationMenuLink
-                    href={product.href}
+                    href={bidirectionalProductLink(product)}
                     className="flex flex-row items-center gap-3 px-4 py-2"
                     arrow
                   >

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -32,6 +32,7 @@ export { fetchPackageInfo } from './npm';
 export { PRODUCTS } from './products';
 export * from './types/components';
 export * from './logos';
+export * from './cn';
 
 declare module 'react' {
   interface CSSProperties {


### PR DESCRIPTION
@saihaj (I think?) proposed linking from docs to landing and landing to docs from Hive tile in Products submenu.
I'm adding new UI to other websites, so I generalized this behavior. Linking to the page I'm already on isn't useful (can always refresh), so I think this matches expectations.