### PR TITLE
Unset Nextra's _subpixel-antialiased

### DIFF
--- a/.changeset/lovely-poems-change.md
+++ b/.changeset/lovely-poems-change.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Unset Nextra's _subpixel-antialiased

--- a/packages/components/style.css
+++ b/packages/components/style.css
@@ -97,4 +97,5 @@
 /* wrong with neue montreal */
 ._subpixel-antialiased {
   -webkit-font-smoothing: unset;
+  -moz-osx-font-smoothing: unset;
 }

--- a/packages/components/style.css
+++ b/packages/components/style.css
@@ -93,3 +93,8 @@
     }
   }
 }
+
+/* wrong with neue montreal */
+._subpixel-antialiased {
+  -webkit-font-smoothing: unset;
+}


### PR DESCRIPTION
`_subpixel-antialiased` makes Neue Montreal too wide and a tad pixelated when you zoom, so we're unsetting it.

https://github.com/user-attachments/assets/c935f9e0-b1cc-4fe2-8b71-b9774c9c4b61

