### PR TITLE
Apply tailwindcss/base layer AFTER Nextra styles

### DIFF
--- a/packages/components/style.css
+++ b/packages/components/style.css
@@ -1,7 +1,8 @@
-@layer l-base, l-nextra, l-components;
+@layer l-nextra, l-base, l-components;
 
-@import 'tailwindcss/base' layer(l-base);
 @import 'nextra-theme-docs/dist/style.css' layer(l-nextra);
+/* the theme must override Nextra styles */
+@import 'tailwindcss/base' layer(l-base);
 @import 'tailwindcss/components' layer(l-components);
 @import 'tailwindcss/utilities';
 


### PR DESCRIPTION
Nextra layer includes Tailwind base styles, including the font on `html`.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5a653bcb-7f10-47ad-9f40-24e899fc2f65">

<img width="282" alt="image" src="https://github.com/user-attachments/assets/2b98633f-af5f-4219-ae13-98678eb68597">
