### PR TITLE
Add the Neue Montreal back to `html`

### DIFF
--- a/.changeset/bright-rules-kiss.md
+++ b/.changeset/bright-rules-kiss.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Add the Neue Montreal back to `html`

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -84,7 +84,7 @@ export function HiveNavigation({
   logo ||= <HiveLogoLink isHive={isHive} />;
   navLinks ||= [
     {
-      href: isHive ? '#pricing' : 'https://the-guild.dev/graphql/hive#pricing',
+      href: isHive ? '/pricing' : 'https://the-guild.dev/graphql/hive/pricing',
       children: 'Pricing',
     },
   ];

--- a/packages/components/style.css
+++ b/packages/components/style.css
@@ -12,6 +12,12 @@
   --nextra-navbar-height: 72px;
 }
 
+html {
+  /* font from tailwindcss/base is overwritten by Nextra styles */
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+}
+
 .nextra-nav-container [role='menu']:has(a[href='https://the-guild.dev/graphql/hive'])
 {
   @apply grid max-h-[unset] w-[470px] grid-cols-3 gap-y-2 p-2;


### PR DESCRIPTION
I noticed we're using San Francisco instead of Neue Montreal lately. (It's not easy to notice, that's why my pet projects always use Papyrus :P)

It happens because the font is overwritten in the l-nextra layer. 

See #1811 for my previous attempt to fix and screenshots.