### PR TITLE
Use green card variant only for Hive

### DIFF
--- a/.changeset/eight-dots-compare.md
+++ b/.changeset/eight-dots-compare.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Use green card variant only for Hive

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -21,6 +21,7 @@ export {
   ToolsAndLibrariesCards,
   MainProductCard,
   AncillaryProductCard,
+  ProductCard,
 } from './tools-and-libraries-cards';
 export * from './decorations';
 export * from './call-to-action';

--- a/packages/components/src/components/tools-and-libraries-cards/index.tsx
+++ b/packages/components/src/components/tools-and-libraries-cards/index.tsx
@@ -60,12 +60,10 @@ export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; produ
   return (
     <Root
       key={product.name}
-      className={
-        cn(
-          'hive-focus-within group relative flex-1 shrink-0 basis-[283.5px] overflow-hidden rounded-2xl bg-blue-400 text-green-1000 max-md:w-[283.5px]',
-          isHive && 'bg-green-1000 text-white'
-        )
-      }
+      className={cn(
+        'hive-focus-within group relative flex-1 shrink-0 basis-[283.5px] overflow-hidden rounded-2xl bg-blue-400 text-green-1000 max-md:w-[283.5px]',
+        isHive && 'bg-green-1000 text-white',
+      )}
     >
       <a
         className="relative z-10 block flex-1 p-8 outline-none focus-visible:outline-none"
@@ -119,5 +117,3 @@ export function AncillaryProductCard({
     </Root>
   );
 }
-
-

--- a/packages/components/src/components/tools-and-libraries-cards/index.tsx
+++ b/packages/components/src/components/tools-and-libraries-cards/index.tsx
@@ -55,10 +55,17 @@ export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; produ
   const Decoration = cardDecorations[product.name];
   const Icon = product.logo;
 
+  const isHive = product.name === PRODUCTS.HIVE.name;
+
   return (
     <Root
       key={product.name}
-      className="hive-focus-within group relative flex-1 shrink-0 basis-[283.5px] overflow-hidden rounded-2xl bg-blue-400 text-green-1000 first-of-type:bg-green-1000 first-of-type:text-white max-md:w-[283.5px]"
+      className={
+        cn(
+          'hive-focus-within group relative flex-1 shrink-0 basis-[283.5px] overflow-hidden rounded-2xl bg-blue-400 text-green-1000 max-md:w-[283.5px]',
+          isHive && 'bg-green-1000 text-white'
+        )
+      }
     >
       <a
         className="relative z-10 block flex-1 p-8 outline-none focus-visible:outline-none"
@@ -70,7 +77,10 @@ export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; produ
       </a>
       <Decoration
         strokeWidth="0.5px"
-        className="pointer-events-none absolute bottom-0 right-0 fill-blue-200 opacity-0 transition-opacity duration-500 group-first-of-type:fill-blue-700 group-focus-within:opacity-100 group-hover:opacity-100"
+        className={cn(
+          'pointer-events-none absolute bottom-0 right-0 fill-blue-200 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100 group-hover:opacity-100',
+          isHive && 'fill-blue-700',
+        )}
         preserveAspectRatio="xMidYMid meet"
       />
       <HighlightDecoration className="pointer-events-none absolute left-0 top-[-15%] h-[150%] w-full opacity-0 transition-opacity duration-1000 group-focus-within:opacity-100 group-hover:opacity-100" />
@@ -109,3 +119,5 @@ export function AncillaryProductCard({
     </Root>
   );
 }
+
+

--- a/packages/components/src/components/tools-and-libraries-cards/index.tsx
+++ b/packages/components/src/components/tools-and-libraries-cards/index.tsx
@@ -51,7 +51,7 @@ export function ToolsAndLibrariesCards({ className }: { className?: string }) {
   );
 }
 
-export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; product: ProductInfo }) {
+export function MainProductCard({ as: Root, product, ...rest }: ProductCardProps) {
   const Decoration = cardDecorations[product.name];
   const Icon = product.logo;
 
@@ -64,6 +64,7 @@ export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; produ
         'hive-focus-within group relative flex-1 shrink-0 basis-[283.5px] overflow-hidden rounded-2xl bg-blue-400 text-green-1000 max-md:w-[283.5px]',
         isHive && 'bg-green-1000 text-white',
       )}
+      {...rest}
     >
       <a
         className="relative z-10 block flex-1 p-8 outline-none focus-visible:outline-none"
@@ -86,18 +87,13 @@ export function MainProductCard({ as: Root, product }: { as: 'div' | 'li'; produ
   );
 }
 
-export function AncillaryProductCard({
-  product,
-  as: Root,
-}: {
-  product: ProductInfo;
-  as: 'div' | 'li';
-}) {
+export function AncillaryProductCard({ product, as: Root, ...rest }: ProductCardProps) {
   const Logo = product.logo;
   return (
     <Root
       key={product.name}
       className="hive-focus-within shrink-0 basis-[283.5px] rounded-2xl bg-beige-200 text-green-1000 transition-colors duration-500 hover:bg-beige-400 max-sm:min-w-[283.5px]"
+      {...rest}
     >
       <a
         href={product.href}
@@ -116,4 +112,15 @@ export function AncillaryProductCard({
       </a>
     </Root>
   );
+}
+
+export interface ProductCardProps extends React.HTMLAttributes<HTMLElement> {
+  as: 'div' | 'li';
+  product: ProductInfo;
+}
+
+export function ProductCard(props: ProductCardProps) {
+  const isMainProduct = FOUR_MAIN_PRODUCTS.map(p => p.name).includes(props.product.name);
+
+  return isMainProduct ? <MainProductCard {...props} /> : <AncillaryProductCard {...props} />;
 }


### PR DESCRIPTION
Without this change, the Yoga card in the /ecosystem page is green.

<img width="606" alt="image" src="https://github.com/user-attachments/assets/81119cbc-cd72-4f27-a9d9-e6d4eeef13df">

