### PR TITLE
Change a link in Navigation CTA to docs

### DIFF
--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -180,9 +180,15 @@ export function HiveNavigation({
         >
           Contact <span className="hidden xl:contents">us</span>
         </CallToAction>
-        <CallToAction variant="primary" href="https://app.graphql-hive.com/" className="ml-4">
-          Sign in
-        </CallToAction>
+        {isHive ? (
+          <CallToAction variant="primary" href="https://app.graphql-hive.com/" className="ml-4">
+            Sign in
+          </CallToAction>
+        ) : (
+          <CallToAction variant="primary" href="/docs" className="ml-4">
+            Docs
+          </CallToAction>
+        )}
       </NavigationMenu>
     </div>
   );


### PR DESCRIPTION
If we're not in Hive website, we're linking to /docs with the primary button in the navigation now.