### PR TITLE
`NextPageProps`

### DIFF
--- a/.changeset/brave-sloths-film.md
+++ b/.changeset/brave-sloths-film.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Add `NextPageProps` utility type

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -19,6 +19,7 @@ export { PRODUCTS } from './products';
 export * from './types/components';
 export * from './logos';
 export { cn } from './cn';
+export * from './next-types';
 
 declare module 'react' {
   interface CSSProperties {

--- a/packages/components/src/next-types.ts
+++ b/packages/components/src/next-types.ts
@@ -1,0 +1,27 @@
+/**
+ * Next.js page props type.
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/page#props
+ * @see https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#good-to-know
+ */
+export interface NextPageProps<
+  TParams extends string = never,
+  TSearchParams extends string = never,
+> {
+  params: Promise<
+    UnionToIntersection<
+      {
+        [K in TParams]: {
+          [F in K extends `...${infer U}` ? U : K]: K extends `...${string}` ? string[] : string;
+        };
+      }[TParams]
+    >
+  >;
+  searchParams: Promise<{ [K in TSearchParams]?: string | string[] }>;
+}
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+type UnionToIntersection<T> = Prettify<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never
+>;


### PR DESCRIPTION
Added `NextPageProps` utility type as seen in the docs. I can guess a reason why they didn't export it, but I'm not exactly a fan of it, so this should help avoid typos even if the injected TypeScript plugin didn't fire.

- https://nextjs.org/docs/app/api-reference/file-conventions/page#props
- https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#good-to-know