### PR TITLE
Add background-color for Nextra search result mark

### DIFF
--- a/.changeset/cool-queens-sparkle.md
+++ b/.changeset/cool-queens-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Add background-color for Nextra search result mark

--- a/packages/components/style.css
+++ b/packages/components/style.css
@@ -67,6 +67,10 @@
   &::before {
     background-color: rgb(229, 231, 235);
   }
+
+  & mark {
+    background-color: oklch(0.611752 0.07807 214.47 / 0.8);
+  }
 }
 
 /* #endregion search results */


### PR DESCRIPTION
If we don't specify this explicitly, we'll get a yellow due to how color CSS Properties are set up.

<img width="657" alt="image" src="https://github.com/user-attachments/assets/9b5c4c92-041e-46d0-96c8-41e2332dd3c5" />
