### PR TITLE
Add Hive-rebranding themed MDX link

### DIFF
--- a/.changeset/bright-apes-shout.md
+++ b/.changeset/bright-apes-shout.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': minor
+---
+
+Add MDXLink and themeVersion option to definedConfig

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -13,7 +13,7 @@ export { InfoList } from './info-list';
 export { LegacyPackageCmd } from './legacy-package-cmd';
 export { MarketplaceList } from './marketplace-list';
 export { MarketplaceSearch } from './marketplace-search';
-export { mdxComponents } from './mdx-components';
+export * from './mdx-components';
 export { NPMBadge } from './npm-badge';
 export { getNavbarLogo } from './guild-navbar-logo';
 export { ThemeSwitcherButton } from './theme-switcher';

--- a/packages/components/src/components/mdx-components/hive-mdx-components.ts
+++ b/packages/components/src/components/mdx-components/hive-mdx-components.ts
@@ -1,0 +1,9 @@
+import { MDXComponents } from 'nextra/mdx';
+import { MDXLink } from './mdx-link';
+
+/**
+ * MDX components used only in Hive-rebranded websites.
+ */
+export const hiveMdxComponents = {
+  a: MDXLink,
+} satisfies MDXComponents;

--- a/packages/components/src/components/mdx-components/index.ts
+++ b/packages/components/src/components/mdx-components/index.ts
@@ -1,2 +1,4 @@
 export * from './mdx-components';
 export * from './hive-mdx-components';
+
+export * from './mdx-link';

--- a/packages/components/src/components/mdx-components/index.ts
+++ b/packages/components/src/components/mdx-components/index.ts
@@ -1,0 +1,2 @@
+export * from './mdx-components';
+export * from './hive-mdx-components';

--- a/packages/components/src/components/mdx-components/mdx-components.tsx
+++ b/packages/components/src/components/mdx-components/mdx-components.tsx
@@ -3,6 +3,10 @@ import { addBasePath } from 'next/dist/client/add-base-path';
 import NextImage from 'next/image';
 import clsx from 'clsx';
 
+/**
+ * MDX components used both in Hive-rebranded websites,
+ * and older The Guild-themed websites.
+ */
 export const mdxComponents: {
   [tag: string]: (props: object) => ReactElement;
 } = {

--- a/packages/components/src/components/mdx-components/mdx-link.stories.ts
+++ b/packages/components/src/components/mdx-components/mdx-link.stories.ts
@@ -6,6 +6,9 @@ export default {
   title: 'Components/MDXLink',
   component: MDXLink,
   decorators: [hiveThemeDecorator],
+  parameters: {
+    padding: true,
+  },
 } satisfies Meta<MDXLinkProps>;
 
 export const Default: StoryObj<MDXLinkProps> = {

--- a/packages/components/src/components/mdx-components/mdx-link.stories.ts
+++ b/packages/components/src/components/mdx-components/mdx-link.stories.ts
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
+import { MDXLink, MDXLinkProps } from './mdx-link';
+
+export default {
+  title: 'Components/MDXLink',
+  component: MDXLink,
+  decorators: [hiveThemeDecorator],
+} satisfies Meta<MDXLinkProps>;
+
+export const Default: StoryObj<MDXLinkProps> = {
+  args: {
+    href: 'https://the-guild.dev/graphql/stitching',
+    children: 'Schema stitching',
+  },
+};

--- a/packages/components/src/components/mdx-components/mdx-link.tsx
+++ b/packages/components/src/components/mdx-components/mdx-link.tsx
@@ -1,0 +1,31 @@
+import { forwardRef } from 'react';
+import { cn } from '../../cn';
+import { Anchor } from '../anchor';
+
+export interface MDXLinkProps
+  extends Omit<React.ComponentProps<typeof Anchor>, 'href' | 'children'> {
+  href?: string;
+  children?: React.ReactNode;
+}
+
+export const MDXLink = forwardRef<HTMLAnchorElement, MDXLinkProps>(
+  ({ className, href, children, ...rest }, ref) => {
+    return (
+      <Anchor
+        ref={ref}
+        // we remove `text-underline-position` from default Nextra link styles, because Neue Montreal font
+        // has a different underline position than system fonts, and it looks bad in Safari.
+        className={cn(
+          'hive-focus -mx-1 -my-0.5 rounded px-1 py-0.5 font-medium text-blue-700 underline underline-offset-2 hover:no-underline focus-visible:no-underline focus-visible:ring-current focus-visible:ring-offset-blue-200 dark:text-primary/90 dark:focus-visible:ring-primary/50',
+          className,
+        )}
+        href={href || ''}
+        {...rest}
+      >
+        {children}
+      </Anchor>
+    );
+  },
+);
+
+MDXLink.displayName = 'MDXLink';

--- a/packages/components/src/define-config.tsx
+++ b/packages/components/src/define-config.tsx
@@ -2,16 +2,19 @@ import { useRouter } from 'next/router';
 import { DocsThemeConfig, Navbar, useConfig } from 'nextra-theme-docs';
 import { Footer, getNavbarLogo, mdxComponents, ThemeSwitcherButton } from './components';
 import { addGuildCompanyMenu } from './components/company-menu';
+import { hiveMdxComponents } from './components/mdx-components';
 
 export interface GuildDocsThemeConfig extends DocsThemeConfig {
   websiteName: string;
   description: string;
+  themeVersion?: 'hive-rebranding' | 'original';
 }
 
 export function defineConfig({
   websiteName,
   description,
   logo,
+  themeVersion = 'original',
   ...config
 }: GuildDocsThemeConfig): DocsThemeConfig {
   if (!config.docsRepositoryBase) {
@@ -106,6 +109,7 @@ export function defineConfig({
     components: {
       ...mdxComponents,
       ...config.components,
+      ...(themeVersion === 'hive-rebranding' && hiveMdxComponents),
     },
   };
 }


### PR DESCRIPTION
<img width="696" alt="image" src="https://github.com/user-attachments/assets/43187c19-d742-447a-9a61-90299a94fdaf" />

This component is meant for use in Hive-rebranding themed websites using Neue Montreal.

I'm following up with PRs to Mesh and GraphQL Codegen websites, and a sibling PR that adds the same component to Components v9.

## Usage

```tsx
defineConfig({
  themeVersion: "hive-rebranding",
  // everything else
})
```