### PR TITLE
Backport `ContactButton` and `ContactTextLink` to v7

### DIFF
--- a/.changeset/fair-masks-behave.md
+++ b/.changeset/fair-masks-behave.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Backport `ContactButton` to v7

--- a/packages/components/src/components/contact-us.stories.tsx
+++ b/packages/components/src/components/contact-us.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { hiveThemeDecorator } from '../../../../.storybook/hive-theme-decorator';
+import {
+  ContactButton,
+  ContactButtonProps,
+  ContactTextLink,
+  ContactTextLinkProps,
+} from './contact-us';
+
+export default {
+  title: 'Components/ContactUs',
+  component: ContactButton,
+  decorators: [hiveThemeDecorator],
+  parameters: {
+    padding: true,
+  },
+} satisfies Meta<ContactButtonProps>;
+
+export const Default: StoryObj<ContactButtonProps> = {
+  name: 'ContactButton',
+  args: {
+    // `children` is optional
+    children: 'Contact us',
+    variant: 'secondary-inverted',
+  },
+};
+
+export const TextLink: StoryObj<ContactTextLinkProps> = {
+  name: 'ContactTextLink',
+  render: args => <ContactTextLink {...args} />,
+  args: {
+    children: 'Reach out to us about the Enterprise plan',
+  },
+};

--- a/packages/components/src/components/contact-us.tsx
+++ b/packages/components/src/components/contact-us.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { cn } from '../cn';
+import { CallToAction, CallToActionProps } from './call-to-action';
+
+const openCrisp = (event: React.MouseEvent<HTMLAnchorElement>) => {
+  if (window.$crisp) {
+    window.$crisp.push(['do', 'chat:open']);
+    event.preventDefault();
+  }
+};
+
+export interface ContactTextLinkProps
+  extends Omit<React.HTMLAttributes<HTMLAnchorElement>, 'href' | 'onClick'> {
+  children?: React.ReactNode;
+}
+
+export function ContactTextLink(props: ContactTextLinkProps) {
+  return (
+    <a
+      {...props}
+      className={cn(
+        'hive-focus -m-2 rounded p-2 font-medium hover:text-blue-700 hover:underline dark:hover:text-blue-100',
+        props.className,
+      )}
+      href="https://the-guild.dev/contact"
+      onClick={openCrisp}
+    >
+      {props.children || 'Contact Us'}
+    </a>
+  );
+}
+
+export interface ContactButtonProps
+  extends Omit<CallToActionProps.AnchorProps, 'onClick' | 'href' | 'children'> {
+  children?: React.ReactNode;
+}
+
+export function ContactButton(props: ContactButtonProps) {
+  return (
+    <CallToAction href="https://the-guild.dev/contact" onClick={openCrisp} {...props}>
+      {props.children || 'Contact Us'}
+    </CallToAction>
+  );
+}


### PR DESCRIPTION
I'm bringing `ContactButton` and `ContactTextLink` from the future, so we can use it in websites that weren't migrated to Nextra 4 yet.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/e36b5cbf-bd65-47f6-8ce9-7246684f9a46" />

It's a simple component that opens Crisp whenever it's available and links to contact page when it isn't.