### PR TITLE
Add `HiveLayout`

### DIFF
--- a/.changeset/slimy-elephants-chew.md
+++ b/.changeset/slimy-elephants-chew.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': minor
+---
+
+Add HiveLayout and HiveLayoutConfig. Tweak HiveNavigation and HiveFooter.

--- a/packages/components/src/components/anchor.tsx
+++ b/packages/components/src/components/anchor.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, ReactElement } from 'react';
 import NextLink from 'next/link';
-import clsx from 'clsx';
+import { cn } from '../cn';
 import { ILink } from '../types/components';
 
 export type AnchorProps = ILink;
@@ -8,7 +8,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function Anchor
   { href = '', children, newWindow, className, ...props },
   forwardedRef,
 ): ReactElement {
-  const classes = clsx(className, 'outline-none transition focus-visible:ring');
+  const classes = cn('outline-none focus-visible:ring', className);
 
   if (typeof href === 'string') {
     if (href.startsWith('#')) {

--- a/packages/components/src/components/hive-footer/index.tsx
+++ b/packages/components/src/components/hive-footer/index.tsx
@@ -6,6 +6,7 @@ import { FOUR_MAIN_PRODUCTS, SIX_HIGHLIGHTED_PRODUCTS } from '../../products';
 import { ILink } from '../../types/components';
 import { Anchor } from '../anchor';
 import { ContactTextLink } from '../contact-us';
+import { __LANDING_WIDTHS_ID } from '../hive-layout-config';
 import {
   CSAStarLevelOneIcon,
   DiscordIcon,
@@ -14,6 +15,21 @@ import {
   TwitterIcon,
   YouTubeIcon,
 } from '../icons/index';
+
+/**
+ * true: max-w-[90rem] (in docs)
+ * false: max-w-[75rem] (in landing pages)
+ */
+const INNER_BOX_WIDTH_STYLE =
+  'max-w-[90rem] [body:has(#hive-l-widths)_&]:max-w-[75rem] [body:has(#hive-l-widths)_&]:mx-4';
+
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line no-console
+  console.assert(
+    __LANDING_WIDTHS_ID === 'hive-l-widths',
+    '__LANDING_WIDTHS_ID diverged from the className used in HiveFooter.',
+  );
+}
 
 export type HiveFooterProps = {
   className?: string;
@@ -33,8 +49,15 @@ export function HiveFooter({
   items = { ...HiveFooter.DEFAULT_ITEMS, ...items };
 
   return (
-    <footer className={cn('relative flex justify-center px-4 py-6 xl:px-[120px]', className)}>
-      <div className="mx-4 grid w-full max-w-[75rem] grid-cols-1 gap-x-6 text-green-800 max-lg:gap-y-16 sm:grid-cols-4 lg:gap-x-8 xl:gap-x-10 dark:text-neutral-400">
+    <footer
+      className={cn('relative flex justify-center px-4 pb-6 pt-[72px] xl:px-[120px]', className)}
+    >
+      <div
+        className={cn(
+          'grid w-full grid-cols-1 gap-x-6 text-green-800 max-lg:gap-y-16 sm:grid-cols-4 lg:gap-x-8 xl:gap-x-10 dark:text-neutral-400',
+          INNER_BOX_WIDTH_STYLE,
+        )}
+      >
         <div className="max-lg:col-span-full">
           <Anchor
             href={href}

--- a/packages/components/src/components/hive-footer/index.tsx
+++ b/packages/components/src/components/hive-footer/index.tsx
@@ -16,10 +16,6 @@ import {
   YouTubeIcon,
 } from '../icons/index';
 
-/**
- * true: max-w-[90rem] (in docs)
- * false: max-w-[75rem] (in landing pages)
- */
 const INNER_BOX_WIDTH_STYLE =
   'max-w-[90rem] [body:has(#hive-l-widths)_&]:max-w-[75rem] [body:has(#hive-l-widths)_&]:mx-4';
 

--- a/packages/components/src/components/hive-layout-config.tsx
+++ b/packages/components/src/components/hive-layout-config.tsx
@@ -1,8 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-unused-vars
-import type { HiveLayout } from '../server/hive-layout';
-
 /**
- * @internal
+ * @internal Don't expose this to websites.
  */
 export const __LANDING_WIDTHS_ID = 'hive-l-widths';
 
@@ -11,7 +8,7 @@ export interface HiveLayoutConfigProps {
 }
 
 /**
- * @see {@link HiveLayout} for documentation.
+ * @see {@link HiveLayout} from `@theguild/components/server` for documentation.
  */
 export function HiveLayoutConfig({ widths }: HiveLayoutConfigProps) {
   return widths === 'landing-narrow' ? <div id={__LANDING_WIDTHS_ID} /> : null;

--- a/packages/components/src/components/hive-layout-config.tsx
+++ b/packages/components/src/components/hive-layout-config.tsx
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports, @typescript-eslint/no-unused-vars
+import type { HiveLayout } from '../server/hive-layout';
+
+/**
+ * @internal
+ */
+export const __LANDING_WIDTHS_ID = 'hive-l-widths';
+
+export interface HiveLayoutConfigProps {
+  widths: 'landing-narrow' | 'docs-wide';
+}
+
+/**
+ * @see {@link HiveLayout} for documentation.
+ */
+export function HiveLayoutConfig({ widths }: HiveLayoutConfigProps) {
+  return widths === 'landing-narrow' ? <div id={__LANDING_WIDTHS_ID} /> : null;
+}

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -22,6 +22,7 @@ import { GraphQLFoundationLogo, GuildLogo, HiveCombinationMark, TheGuild } from 
 import { PRODUCTS, SIX_HIGHLIGHTED_PRODUCTS } from '../../products';
 import { Anchor } from '../anchor';
 import { CallToAction } from '../call-to-action';
+import { __LANDING_WIDTHS_ID } from '../hive-layout-config';
 import {
   AccountBox,
   AppsIcon,
@@ -44,6 +45,16 @@ import {
 export * from './graphql-conf-card';
 
 const ENTERPRISE_MENU_HIDDEN = true;
+
+const WIDTH_STYLE = 'max-w-[90rem] [body:has(#hive-l-widths)_&]:max-w-[1392px]';
+
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line no-console
+  console.assert(
+    __LANDING_WIDTHS_ID === 'hive-l-widths',
+    '__LANDING_WIDTHS_ID diverged from the className used in HiveNavigation.',
+  );
+}
 
 export type HiveNavigationProps = {
   companyMenuChildren?: ReactNode;
@@ -93,8 +104,8 @@ export function HiveNavigation({
     <div
       ref={containerRef}
       className={cn(
-        'sticky top-0 z-20 border-b border-beige-400/[var(--border-opacity)] bg-[rgb(var(--nextra-bg))] px-6 py-4 text-green-1000 transition-[border-color] duration-500 md:mb-[7px] md:mt-2 dark:border-neutral-700/[var(--border-opacity)] dark:text-neutral-200 [&.light]:border-beige-400/[var(--border-opacity)] [&.light]:bg-white [&.light]:text-green-1000',
-        className?.includes('light') && 'light',
+        'sticky top-0 z-20 border-b border-beige-400/[var(--border-opacity)] bg-[rgb(var(--nextra-bg))] px-6 py-4 text-green-1000 transition-[border-color] duration-500 md:mb-[7px] md:mt-2 dark:border-neutral-700/[var(--border-opacity)] dark:text-neutral-200',
+        WIDTH_STYLE,
       )}
       style={{ '--border-opacity': 0 }}
     >

--- a/packages/components/src/components/hive-navigation/index.tsx
+++ b/packages/components/src/components/hive-navigation/index.tsx
@@ -68,7 +68,6 @@ export type HiveNavigationProps = {
   navLinks?: { href: string; children: ReactNode }[];
   developerMenu: DeveloperMenuProps['developerMenu'];
   search?: ReactElement;
-  searchProps?: ComponentProps<typeof Search>;
 };
 
 /**
@@ -96,7 +95,9 @@ export function HiveNavigation({
     },
   ],
   developerMenu,
-  search = <Search />,
+  // we need the background transition disabled to avoid an unpleasant flicker
+  // when navigating from a forced light mode page to a dark mode page
+  search = <Search className="[&_input]:transition-none" />,
 }: HiveNavigationProps) {
   const containerRef = useRef<HTMLDivElement>(null!);
 

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -34,3 +34,4 @@ export * from './version-dropdown';
 export * from './dropdown';
 export { FrequentlyAskedQuestions } from './faq';
 export { ComparisonTable } from './comparison-table';
+export { HiveLayoutConfig } from './hive-layout-config';

--- a/packages/components/src/server/body.client.tsx
+++ b/packages/components/src/server/body.client.tsx
@@ -1,15 +1,21 @@
 'use client';
 
-import { FC, ReactNode } from 'react';
+import { DetailedHTMLProps, FC, HtmlHTMLAttributes } from 'react';
 import { usePathname } from 'next/navigation';
+import { cn } from '../cn';
 
-export const Body: FC<{
-  lightOnlyPages: string[];
-  children: ReactNode;
-}> = ({ lightOnlyPages, children }) => {
+export interface BodyProps
+  extends DetailedHTMLProps<HtmlHTMLAttributes<HTMLBodyElement>, HTMLBodyElement> {
+  lightOnlyPages?: string[];
+}
+
+export const Body: FC<BodyProps> = ({ lightOnlyPages, children, className, ...rest }) => {
   const pathname = usePathname();
+  const isLightOnlyPage = lightOnlyPages?.includes(pathname);
 
-  const isLightOnlyPage = lightOnlyPages.includes(pathname);
-
-  return <body className={isLightOnlyPage ? 'light text-green-1000' : undefined}>{children}</body>;
+  return (
+    <body className={cn(className, isLightOnlyPage && 'light text-green-1000')} {...rest}>
+      {children}
+    </body>
+  );
 };

--- a/packages/components/src/server/hive-layout.tsx
+++ b/packages/components/src/server/hive-layout.tsx
@@ -14,6 +14,7 @@ export interface HiveLayoutProps
   fontFamily: string;
   lightOnlyPages: string[];
   bodyProps?: DetailedHTMLProps<HtmlHTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+  docsRepositoryBase: string;
 }
 
 /**
@@ -62,6 +63,7 @@ export const HiveLayout = async ({
   fontFamily,
   lightOnlyPages,
   bodyProps,
+  docsRepositoryBase,
   ...rest
 }: HiveLayoutProps) => {
   const pageMap = await getPageMap();
@@ -123,7 +125,7 @@ export const HiveLayout = async ({
       <Body lightOnlyPages={lightOnlyPages} {...bodyProps}>
         <Layout
           editLink="Edit this page on GitHub"
-          docsRepositoryBase="https://github.com/graphql-hive/platform/tree/main/packages/web/docs"
+          docsRepositoryBase={docsRepositoryBase}
           pageMap={pageMap}
           feedback={{
             labels: 'kind/docs',

--- a/packages/components/src/server/hive-layout.tsx
+++ b/packages/components/src/server/hive-layout.tsx
@@ -20,6 +20,37 @@ export interface HiveLayoutProps
  *
  * Accepts navbar and footer as slots/children props, because they're highly customizable,
  * and their defaults belong to HiveNavigation and HiveFooter component default props.
+ *
+ * ## Configuration
+ *
+ * Pages can differ by widths and supported color schemes:
+ *
+ * - The footer in docs has 90rem width, in landing pages it has 75rem.
+ * - The navbar in docs has 90rem width, in landing pages it has 1392px.
+ * - Landing pages only support light mode for _business and prioritization reasons_.
+ *
+ * TODO: Consider unifying this in design phase.
+ *
+ * For now, a page or a layout can configue these as follows:
+ *
+ * ### Light-only pages
+ *
+ * @example
+ * ```tsx
+ * <HiveLayout bodyProps={{ lightOnlyPages: ['/', '/friends'] }} />
+ * ```
+ *
+ * This will force light theme to the pages with paths `/` and `/friends`,
+ * by adding `.light` class to the <body /> element.
+ *
+ * ### Landing page widths
+ *
+ * @example
+ * ```tsx
+ * import { HiveLayoutConfig } from '@theguild/components'
+ *
+ * <HiveLayoutConfig widths="landing-narrow" />
+ * ```
  */
 export const HiveLayout = async ({
   children,
@@ -57,7 +88,7 @@ export const HiveLayout = async ({
           :root.dark *::selection {
             background-color: hsl(191deg 95% 72% / 0.25)
           }
-          :root.light, body.light {
+          :root.light, :root.dark:has(body.light) {
             --nextra-primary-hue: 191deg;
             --nextra-primary-saturation: 40%;
             --nextra-bg: 255, 255, 255;

--- a/packages/components/src/server/hive-layout.tsx
+++ b/packages/components/src/server/hive-layout.tsx
@@ -12,7 +12,8 @@ export interface HiveLayoutProps
   navbar: ReactElement;
   footer: ReactElement;
   fontFamily: string;
-  bodyProps: BodyProps;
+  lightOnlyPages: string[];
+  bodyProps?: DetailedHTMLProps<HtmlHTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
 }
 
 /**
@@ -59,6 +60,7 @@ export const HiveLayout = async ({
   footer,
   className,
   fontFamily,
+  lightOnlyPages,
   bodyProps,
   ...rest
 }: HiveLayoutProps) => {
@@ -118,7 +120,7 @@ export const HiveLayout = async ({
         }</style>
         {head}
       </Head>
-      <Body {...bodyProps}>
+      <Body lightOnlyPages={lightOnlyPages} {...bodyProps}>
         <Layout
           editLink="Edit this page on GitHub"
           docsRepositoryBase="https://github.com/graphql-hive/platform/tree/main/packages/web/docs"

--- a/packages/components/src/server/hive-layout.tsx
+++ b/packages/components/src/server/hive-layout.tsx
@@ -3,7 +3,7 @@ import { Layout } from 'nextra-theme-docs';
 import { Head } from 'nextra/components';
 import { getPageMap } from 'nextra/page-map';
 import { cn } from '../cn';
-import { Body, BodyProps } from './body.client';
+import { Body } from './body.client';
 
 export interface HiveLayoutProps
   extends DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> {

--- a/packages/components/src/server/hive-layout.tsx
+++ b/packages/components/src/server/hive-layout.tsx
@@ -1,0 +1,109 @@
+import { DetailedHTMLProps, HtmlHTMLAttributes, ReactElement, ReactNode } from 'react';
+import { Layout } from 'nextra-theme-docs';
+import { Head } from 'nextra/components';
+import { getPageMap } from 'nextra/page-map';
+import { cn } from '../cn';
+import { Body, BodyProps } from './body.client';
+
+export interface HiveLayoutProps
+  extends DetailedHTMLProps<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement> {
+  children: ReactNode;
+  head: ReactNode;
+  navbar: ReactElement;
+  footer: ReactElement;
+  fontFamily: string;
+  bodyProps: BodyProps;
+}
+
+/**
+ * Alternative to `GuildLayout` for Hive-branded websites.
+ *
+ * Accepts navbar and footer as slots/children props, because they're highly customizable,
+ * and their defaults belong to HiveNavigation and HiveFooter component default props.
+ */
+export const HiveLayout = async ({
+  children,
+  head,
+  navbar,
+  footer,
+  className,
+  fontFamily,
+  bodyProps,
+  ...rest
+}: HiveLayoutProps) => {
+  const pageMap = await getPageMap();
+  return (
+    <html
+      lang="en"
+      // Required to be set for `nextra-theme-docs` styles
+      dir="ltr"
+      // Suggested by `next-themes` package https://github.com/pacocoursey/next-themes#with-app
+      suppressHydrationWarning
+      className={cn('font-sans', className)}
+      {...rest}
+    >
+      <Head>
+        <style>{
+          /* css */ `
+          :root {
+            --font-sans: ${fontFamily};
+          }
+          :root.dark {
+            --nextra-primary-hue: 67.1deg;
+            --nextra-primary-saturation: 100%;
+            --nextra-primary-lightness: 55%;
+            --nextra-bg: 17, 17, 17;
+          }
+          :root.dark *::selection {
+            background-color: hsl(191deg 95% 72% / 0.25)
+          }
+          :root.light, body.light {
+            --nextra-primary-hue: 191deg;
+            --nextra-primary-saturation: 40%;
+            --nextra-bg: 255, 255, 255;
+          }
+          
+          .x\\:tracking-tight,
+          .nextra-steps :is(h2, h3, h4) {
+            letter-spacing: normal;
+          }
+
+          html:has(body.light) {
+            scroll-behavior: smooth;
+            background: #fff;
+            color-scheme: light !important;
+          }
+          
+          html:has(body.light) .nextra-search-results mark {
+            background: oklch(0.611752 0.07807 214.47 / 0.8);
+          }
+          
+          html:has(body.light) .nextra-sidebar-footer {
+            display: none;
+          }
+          
+          #crisp-chatbox { z-index: 40 !important; }
+        `
+        }</style>
+        {head}
+      </Head>
+      <Body {...bodyProps}>
+        <Layout
+          editLink="Edit this page on GitHub"
+          docsRepositoryBase="https://github.com/graphql-hive/platform/tree/main/packages/web/docs"
+          pageMap={pageMap}
+          feedback={{
+            labels: 'kind/docs',
+          }}
+          sidebar={{
+            defaultMenuCollapseLevel: 1,
+          }}
+          navbar={navbar}
+          footer={footer}
+        >
+          {children}
+        </Layout>
+      </Body>
+    </html>
+  );
+};

--- a/packages/components/src/server/index.ts
+++ b/packages/components/src/server/index.ts
@@ -15,7 +15,7 @@ export {
 export { evaluate } from 'nextra/evaluate';
 export { fetchPackageInfo } from './npm.js';
 export { sharedMetaItems } from './shared-meta-items.js';
-export { Body, BodyProps } from './body.client.js';
+export * from './body.client.js';
 export { remarkLinkRewrite } from './remark-link-rewrite.js';
 
 /**

--- a/packages/components/src/server/index.ts
+++ b/packages/components/src/server/index.ts
@@ -15,7 +15,7 @@ export {
 export { evaluate } from 'nextra/evaluate';
 export { fetchPackageInfo } from './npm.js';
 export { sharedMetaItems } from './shared-meta-items.js';
-export { Body } from './body.client.js';
+export { Body, BodyProps } from './body.client.js';
 export { remarkLinkRewrite } from './remark-link-rewrite.js';
 
 /**

--- a/packages/components/src/server/index.ts
+++ b/packages/components/src/server/index.ts
@@ -26,3 +26,4 @@ export { remarkLinkRewrite } from './remark-link-rewrite.js';
  * which is disallowed. Either remove the export, or the "use client" directive. Read more: https://nextjs.org
  */
 export { GuildLayout, getDefaultMetadata } from './theme-layout.js';
+export { HiveLayout } from './hive-layout.js';

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { getDefaultMetadata, GuildLayout } from '@theguild/components/server';
 import '@theguild/components/style.css';
-import { GitHubIcon, PaperIcon, PencilIcon } from '@theguild/components';
+import { GitHubIcon, PaperIcon, PencilIcon, Search } from '@theguild/components';
 
 const description = 'Documentation for The Guild';
 const websiteName = 'Guild Docs';
@@ -35,9 +35,6 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
       }}
       navbarProps={{
         navLinks: [{ href: '/docs', children: 'Documentation' }],
-        searchProps: {
-          placeholder: 'Search...',
-        },
         developerMenu: [
           {
             href: '/docs',
@@ -55,6 +52,7 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
             children: 'GitHub',
           },
         ],
+        search: <Search placeholder="Search..." className="[&_input]:transition-none" />,
       }}
       lightOnlyPages={['/']}
     >


### PR DESCRIPTION
This PR pulls in some complexity of using and configuring a Hive layout into `@theguild/docs`. 

Ideally, we wouldn't concern ourselves with styling in layout components of websites, just with configuration props — what links we render, what logo we have. This is a move in that direction.