### PR TITLE
using `<NextLink>` instead `<a>` to avoid using `import { addBasePath } from 'next/dist/client/add-base-path'`

### DIFF
--- a/.changeset/gold-clouds-guess.md
+++ b/.changeset/gold-clouds-guess.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+using `<NextLink>` instead `<a>` to avoid using `import { addBasePath } from 'next/dist/client/add-base-path'`

--- a/packages/components/src/components/dropdown.tsx
+++ b/packages/components/src/components/dropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useId, useRef, useState } from 'react';
+import NextLink from 'next/link';
 import { cn } from '../cn';
 
 interface DropdownContextValue {
@@ -169,9 +170,9 @@ interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
 export function DropdownItem({ children, onClick, className, href, ...props }: DropdownItemProps) {
   if (href) {
     return (
-      <a role="menuitem" href={href} className={className} onClick={onClick} {...props}>
+      <NextLink role="menuitem" href={href} className={className} onClick={onClick} {...props}>
         {children}
-      </a>
+      </NextLink>
     );
   }
 


### PR DESCRIPTION
better fix of https://github.com/ardatan/graphql-mesh/pull/8288/files cc @hasparus 