### PR TITLE
Hero section v2

### DIFF
--- a/.changeset/calm-ducks-rest.md
+++ b/.changeset/calm-ducks-rest.md
@@ -1,0 +1,8 @@
+---
+"@theguild/components": minor
+---
+
+Hero section v2:
+
+- Change `logo` prop to `top={{ logo: }}`
+- Remove decorations

--- a/packages/components/src/components/hero/index.stories.tsx
+++ b/packages/components/src/components/hero/index.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react';
 import { GitHubIcon } from 'nextra/icons';
 import { Meta, StoryObj } from '@storybook/react';
 import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
-import { MeshLogo, ModulesLogo } from '../../logos';
+import { ModulesLogo } from '../../logos';
 import { CallToAction } from '../call-to-action';
 import { Hero } from './index';
 

--- a/packages/components/src/components/hero/index.stories.tsx
+++ b/packages/components/src/components/hero/index.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react';
 import { GitHubIcon } from 'nextra/icons';
 import { Meta, StoryObj } from '@storybook/react';
 import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
-import { ModulesLogo } from '../../logos';
+import { MeshLogo, ModulesLogo } from '../../logos';
 import { CallToAction } from '../call-to-action';
 import { Hero } from './index';
 
@@ -20,8 +20,8 @@ export default {
     checkmarks: {
       name: 'Checkmarks text',
     },
-    logo: {
-      name: 'Logo',
+    top: {
+      logo: <ModulesLogo />,
     },
     text: {
       name: 'Hero text',
@@ -33,7 +33,9 @@ export const Default: StoryObj<ComponentProps<typeof Hero>> = {
   args: {
     heading: 'Enterprise Grade Tooling for Your GraphQL Server',
     text: 'GraphQL Modules is a toolset of libraries and guidelines dedicated to create reusable, maintainable, testable and extendable modules out of your GraphQL server.',
-    logo: <ModulesLogo />,
+    top: {
+      logo: <ModulesLogo />,
+    },
     checkmarks: ['Fully open source', 'No vendor lock'],
     children: (
       <>

--- a/packages/components/src/components/hero/index.tsx
+++ b/packages/components/src/components/hero/index.tsx
@@ -8,7 +8,13 @@ export interface HeroProps {
   heading: string;
   text: string;
   checkmarks: string[];
-  logo?: ReactElement<{ className?: string; fill?: string }>;
+  top?:
+    | {
+        logo: ReactElement<{ className?: string; fill?: string }>;
+      }
+    | {
+        children: ReactNode;
+      };
   children?: ReactNode;
 }
 
@@ -25,14 +31,16 @@ export const Hero: FC<HeroProps> = props => {
       )}
     >
       <div className="relative">
-        {props.logo &&
-          cloneElement(props.logo, {
-            fill: `url(#${gradientWhiteId})`,
-            className: cn(
-              'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
-              props.logo.props.className,
-            ),
-          })}
+        {props.top &&
+          ('logo' in props.top
+            ? cloneElement(props.top.logo, {
+                fill: `url(#${gradientWhiteId})`,
+                className: cn(
+                  'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
+                  props.top.logo.props.className,
+                ),
+              })
+            : props.top.children)}
         <svg
           width="96"
           height="96"

--- a/packages/components/src/components/hero/index.tsx
+++ b/packages/components/src/components/hero/index.tsx
@@ -32,68 +32,72 @@ export const Hero: FC<HeroProps> = props => {
     >
       <div className="relative">
         {props.top &&
-          ('logo' in props.top
-            ? cloneElement(props.top.logo, {
+          ('logo' in props.top ? (
+            <>
+              {cloneElement(props.top.logo, {
                 fill: `url(#${gradientWhiteId})`,
                 className: cn(
                   'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
                   props.top.logo.props.className,
                 ),
-              })
-            : props.top.children)}
-        <svg
-          width="96"
-          height="96"
-          viewBox="0 0 96 96"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <rect width="96" height="96" rx="24" fill={`url(#${greenBgId})`} />
-          <rect
-            x="0.5"
-            y="0.5"
-            width="95"
-            height="95"
-            rx="23.5"
-            stroke={`url(#${gradientWhiteId})`}
-          />
-          <path d="M57.0264 32.1652H48.9577L53.8032 27.3197L48.4855 22L43.1658 27.3197L48.0114 32.1652H39.9427C38.9042 32.1652 37.9069 32.5786 37.1721 33.3134L23 47.4855L28.3197 52.8052L45.715 35.4099C47.2452 33.8797 49.7258 33.8797 51.2561 35.4099L68.6513 52.8052L73.971 47.4855L59.797 33.3114C59.0622 32.5767 58.0649 32.1632 57.0264 32.1632V32.1652ZM48.4854 63.3623L43.1665 68.6811L48.4854 74L53.8042 68.6811L48.4854 63.3623ZM39.9446 52.8054H48.4855H48.4894H57.0303C58.0688 52.8054 59.0661 53.2188 59.8008 53.9536L63.89 58.0428L58.5704 63.3625L51.258 56.0501C49.7277 54.5198 47.2472 54.5198 45.7169 56.0501L38.4045 63.3625L33.0848 58.0428L37.174 53.9536C37.9088 53.2188 38.9061 52.8054 39.9446 52.8054Z" />
-          <defs>
-            <linearGradient
-              id={greenBgId}
-              x1="0"
-              y1="0"
-              x2="96"
-              y2="96"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="#3B736A" />
-              <stop offset="1" stopColor="#15433C" />
-            </linearGradient>
-            <linearGradient
-              id={gradientWhiteId}
-              x1="0"
-              y1="0"
-              x2="96"
-              y2="96"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="white" stopOpacity="0.8" />
-              <stop offset="1" stopColor="white" stopOpacity="0.4" />
-            </linearGradient>
-            <linearGradient
-              id={gradientWhiteId2}
-              x1="1"
-              y1="2"
-              x2="161"
-              y2="171"
-              gradientUnits="userSpaceOnUse"
-            >
-              <stop stopColor="white" stopOpacity="0.1" />
-              <stop offset="1" stopColor="white" stopOpacity="0.5" />
-            </linearGradient>
-          </defs>
-        </svg>
+              })}
+              <svg
+                width="96"
+                height="96"
+                viewBox="0 0 96 96"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect width="96" height="96" rx="24" fill={`url(#${greenBgId})`} />
+                <rect
+                  x="0.5"
+                  y="0.5"
+                  width="95"
+                  height="95"
+                  rx="23.5"
+                  stroke={`url(#${gradientWhiteId})`}
+                />
+                <path d="M57.0264 32.1652H48.9577L53.8032 27.3197L48.4855 22L43.1658 27.3197L48.0114 32.1652H39.9427C38.9042 32.1652 37.9069 32.5786 37.1721 33.3134L23 47.4855L28.3197 52.8052L45.715 35.4099C47.2452 33.8797 49.7258 33.8797 51.2561 35.4099L68.6513 52.8052L73.971 47.4855L59.797 33.3114C59.0622 32.5767 58.0649 32.1632 57.0264 32.1632V32.1652ZM48.4854 63.3623L43.1665 68.6811L48.4854 74L53.8042 68.6811L48.4854 63.3623ZM39.9446 52.8054H48.4855H48.4894H57.0303C58.0688 52.8054 59.0661 53.2188 59.8008 53.9536L63.89 58.0428L58.5704 63.3625L51.258 56.0501C49.7277 54.5198 47.2472 54.5198 45.7169 56.0501L38.4045 63.3625L33.0848 58.0428L37.174 53.9536C37.9088 53.2188 38.9061 52.8054 39.9446 52.8054Z" />
+                <defs>
+                  <linearGradient
+                    id={greenBgId}
+                    x1="0"
+                    y1="0"
+                    x2="96"
+                    y2="96"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stopColor="#3B736A" />
+                    <stop offset="1" stopColor="#15433C" />
+                  </linearGradient>
+                  <linearGradient
+                    id={gradientWhiteId}
+                    x1="0"
+                    y1="0"
+                    x2="96"
+                    y2="96"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stopColor="white" stopOpacity="0.8" />
+                    <stop offset="1" stopColor="white" stopOpacity="0.4" />
+                  </linearGradient>
+                  <linearGradient
+                    id={gradientWhiteId2}
+                    x1="1"
+                    y1="2"
+                    x2="161"
+                    y2="171"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop stopColor="white" stopOpacity="0.1" />
+                    <stop offset="1" stopColor="white" stopOpacity="0.5" />
+                  </linearGradient>
+                </defs>
+              </svg>
+            </>
+          ) : (
+            props.top.children
+          ))}
       </div>
       <Heading as="h1" size="xl" className="mx-auto max-w-3xl text-balance text-center">
         {props.heading}

--- a/packages/components/src/components/hero/index.tsx
+++ b/packages/components/src/components/hero/index.tsx
@@ -1,17 +1,18 @@
-import { cloneElement, ComponentProps, FC, ReactElement, ReactNode, useId } from 'react';
+import { cloneElement, FC, ReactElement, ReactNode, useId } from 'react';
 import { cn } from '../../cn';
-import { DecorationIsolation } from '../decorations';
 import { Heading } from '../heading';
 import { CheckIcon } from '../icons';
 
-export const Hero: FC<{
+export interface HeroProps {
   className?: string;
   heading: string;
   text: string;
   checkmarks: string[];
-  logo: ReactElement<ComponentProps<'svg'>>;
+  logo?: ReactElement<{ className?: string; fill?: string }>;
   children?: ReactNode;
-}> = props => {
+}
+
+export const Hero: FC<HeroProps> = props => {
   const gradientWhiteId = useId();
   const gradientWhiteId2 = useId();
   const greenBgId = useId();
@@ -23,33 +24,15 @@ export const Hero: FC<{
         props.className,
       )}
     >
-      <DecorationIsolation className="-z-10">
-        {cloneElement(props.logo, {
-          className: cn(
-            'absolute stroke-white/10 max-lg:hidden',
-            '-left-1/2 top-1/2 -translate-y-1/2',
-          ),
-          fill: `url(#${gradientWhiteId2})`,
-          strokeWidth: '0.1',
-          width: 'auto',
-          height: '50%',
-        })}
-        {cloneElement(props.logo, {
-          className: cn(
-            'absolute top-1/2 -translate-y-1/2 stroke-white/10',
-            '-right-1/2 lg:-right-1/3',
-            'h-2/3 lg:h-[calc(100%-5%)]',
-          ),
-          fill: `url(#${gradientWhiteId2})`,
-          strokeWidth: '0.1',
-          width: 'auto',
-        })}
-      </DecorationIsolation>
       <div className="relative">
-        {cloneElement(props.logo, {
-          fill: `url(#${gradientWhiteId})`,
-          className: 'absolute inset-1/2 -translate-x-1/2 -translate-y-1/2 size-1/2',
-        })}
+        {props.logo &&
+          cloneElement(props.logo, {
+            fill: `url(#${gradientWhiteId})`,
+            className: cn(
+              'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
+              props.logo.props.className,
+            ),
+          })}
         <svg
           width="96"
           height="96"


### PR DESCRIPTION
This PR updates `Hero` to make it usable in place of existing copy-pasted Hero callsites.

## Reasoning

1. We can't have decorations here, because we have _a lot_ of different configurations of them.
2. We also can't derive it from `props.logo`, because logo is optional. We have multiple landing pages without a logo, including one with a text there.

<img width="777" alt="image" src="https://github.com/user-attachments/assets/3c057e3d-b9cb-40b8-980e-b33c36f4a4ac" />

## Disclaimer

This PR is breaking, but I don't want to cut v10 just for it. Right now Hero is used just in one place.