### PR TITLE
Hero section revamped

### DIFF
--- a/.changeset/fifty-maps-sparkle.md
+++ b/.changeset/fifty-maps-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Add a readymade way to make a simple decoration for library websites back.

--- a/packages/components/src/components/decorations/index.tsx
+++ b/packages/components/src/components/decorations/index.tsx
@@ -5,10 +5,12 @@ export { ReactComponent as ArchDecorationGradientDefs } from './arch-decoration-
 export { ReactComponent as HighlightDecoration } from './highlight-decoration.svg';
 export { ReactComponent as LargeHiveIconDecoration } from './large-hive-icon-decoration.svg';
 
+export type DecorationIsolationProps = React.HTMLAttributes<HTMLDivElement>;
+
 /**
  * Decorations must be isolated, as clicking id links scrolls the container with overflow: hidden.
  */
-export function DecorationIsolation(props: React.HTMLAttributes<HTMLDivElement>) {
+export function DecorationIsolation(props: DecorationIsolationProps) {
   return (
     <div
       {...props}

--- a/packages/components/src/components/hero/hero-decoration-from-logo.tsx
+++ b/packages/components/src/components/hero/hero-decoration-from-logo.tsx
@@ -11,14 +11,12 @@ export function HeroDecorationFromLogo({ logo, ...rest }: HeroDecorationFromLogo
   return (
     <DecorationIsolation {...rest} className={cn('-z-10', rest.className)}>
       {cloneElement(logo, {
-        className: cn(
-          'absolute stroke-white/10 max-lg:hidden',
-          '-left-1/2 top-1/2 -translate-y-1/2',
-        ),
-        fill: `url(#${GRADIENT_WHITE_ID})`,
+        className: cn('absolute -left-1/2 top-1/2 -translate-y-1/2 stroke-white/10 max-lg:hidden'),
+        fill: `url(#${GRADIENT_WHITE_2_ID})`,
         strokeWidth: '0.1',
-        width: 'auto',
         height: '50%',
+        width: 'auto',
+        opacity: 0.8,
       })}
       {cloneElement(logo, {
         className: cn(
@@ -29,6 +27,7 @@ export function HeroDecorationFromLogo({ logo, ...rest }: HeroDecorationFromLogo
         fill: `url(#${GRADIENT_WHITE_2_ID})`,
         strokeWidth: '0.1',
         width: 'auto',
+        opacity: 0.6,
       })}
     </DecorationIsolation>
   );

--- a/packages/components/src/components/hero/hero-decoration-from-logo.tsx
+++ b/packages/components/src/components/hero/hero-decoration-from-logo.tsx
@@ -1,0 +1,35 @@
+import { cloneElement, ReactElement } from 'react';
+import { cn } from '../../cn';
+import { DecorationIsolation, DecorationIsolationProps } from '../decorations';
+import { GRADIENT_WHITE_2_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
+
+export interface HeroDecorationFromLogoProps extends DecorationIsolationProps {
+  logo: ReactElement;
+}
+
+export function HeroDecorationFromLogo({ logo, ...rest }: HeroDecorationFromLogoProps) {
+  return (
+    <DecorationIsolation {...rest} className={cn('-z-10', rest.className)}>
+      {cloneElement(logo, {
+        className: cn(
+          'absolute stroke-white/10 max-lg:hidden',
+          '-left-1/2 top-1/2 -translate-y-1/2',
+        ),
+        fill: `url(#${GRADIENT_WHITE_ID})`,
+        strokeWidth: '0.1',
+        width: 'auto',
+        height: '50%',
+      })}
+      {cloneElement(logo, {
+        className: cn(
+          'absolute top-1/2 -translate-y-1/2 stroke-white/10',
+          '-right-1/2 lg:-right-1/3',
+          'h-2/3 lg:h-[calc(100%-5%)]',
+        ),
+        fill: `url(#${GRADIENT_WHITE_2_ID})`,
+        strokeWidth: '0.1',
+        width: 'auto',
+      })}
+    </DecorationIsolation>
+  );
+}

--- a/packages/components/src/components/hero/hero-decoration-from-logo.tsx
+++ b/packages/components/src/components/hero/hero-decoration-from-logo.tsx
@@ -1,7 +1,7 @@
 import { cloneElement, ReactElement } from 'react';
 import { cn } from '../../cn';
 import { DecorationIsolation, DecorationIsolationProps } from '../decorations';
-import { GRADIENT_WHITE_2_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
+import { GRADIENT_WHITE_2_ID } from './hero-gradient-ids';
 
 export interface HeroDecorationFromLogoProps extends DecorationIsolationProps {
   logo: ReactElement;

--- a/packages/components/src/components/hero/hero-gradient-defs.tsx
+++ b/packages/components/src/components/hero/hero-gradient-defs.tsx
@@ -16,8 +16,8 @@ export function HeroGradientDefs() {
           <stop offset="1" stopColor="#15433C" />
         </linearGradient>
         <linearGradient id={GRADIENT_WHITE_ID} x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop stopColor="#fff" stopOpacity="1" />
-          <stop offset="1" stopColor="#fff" stopOpacity="0.5" />
+          <stop stopColor="#fff" stopOpacity="0.8" />
+          <stop offset="1" stopColor="#fff" stopOpacity="0.4" />
         </linearGradient>
         <linearGradient id={GRADIENT_WHITE_2_ID} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop stopColor="#fff" stopOpacity="0.1" />

--- a/packages/components/src/components/hero/hero-gradient-defs.tsx
+++ b/packages/components/src/components/hero/hero-gradient-defs.tsx
@@ -6,44 +6,22 @@ export function HeroGradientDefs() {
       width="96"
       height="96"
       viewBox="0 0 96 96"
-      fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className="pointer-events-none absolute"
       aria-hidden
     >
       <defs>
-        <linearGradient
-          id={GRADIENT_GREEN_ID}
-          x1="0"
-          y1="0"
-          x2="96"
-          y2="96"
-          gradientUnits="userSpaceOnUse"
-        >
+        <linearGradient id={GRADIENT_GREEN_ID} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop stopColor="#3B736A" />
           <stop offset="1" stopColor="#15433C" />
         </linearGradient>
-        <linearGradient
-          id={GRADIENT_WHITE_ID}
-          x1="0"
-          y1="0"
-          x2="96"
-          y2="96"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="white" stopOpacity="0.8" />
-          <stop offset="1" stopColor="white" stopOpacity="0.4" />
+        <linearGradient id={GRADIENT_WHITE_ID} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop stopColor="#fff" stopOpacity="1" />
+          <stop offset="1" stopColor="#fff" stopOpacity="0.5" />
         </linearGradient>
-        <linearGradient
-          id={GRADIENT_WHITE_2_ID}
-          x1="1"
-          y1="2"
-          x2="161"
-          y2="171"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="white" stopOpacity="0.1" />
-          <stop offset="1" stopColor="white" stopOpacity="0.5" />
+        <linearGradient id={GRADIENT_WHITE_2_ID} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop stopColor="#fff" stopOpacity="0.1" />
+          <stop offset="1" stopColor="#fff" stopOpacity="0.5" />
         </linearGradient>
       </defs>
     </svg>

--- a/packages/components/src/components/hero/hero-gradient-defs.tsx
+++ b/packages/components/src/components/hero/hero-gradient-defs.tsx
@@ -1,0 +1,51 @@
+import { GRADIENT_GREEN_ID, GRADIENT_WHITE_2_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
+
+export function HeroGradientDefs() {
+  return (
+    <svg
+      width="96"
+      height="96"
+      viewBox="0 0 96 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="pointer-events-none absolute"
+      aria-hidden
+    >
+      <defs>
+        <linearGradient
+          id={GRADIENT_GREEN_ID}
+          x1="0"
+          y1="0"
+          x2="96"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#3B736A" />
+          <stop offset="1" stopColor="#15433C" />
+        </linearGradient>
+        <linearGradient
+          id={GRADIENT_WHITE_ID}
+          x1="0"
+          y1="0"
+          x2="96"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="white" stopOpacity="0.8" />
+          <stop offset="1" stopColor="white" stopOpacity="0.4" />
+        </linearGradient>
+        <linearGradient
+          id={GRADIENT_WHITE_2_ID}
+          x1="1"
+          y1="2"
+          x2="161"
+          y2="171"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="white" stopOpacity="0.1" />
+          <stop offset="1" stopColor="white" stopOpacity="0.5" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/packages/components/src/components/hero/hero-gradient-ids.ts
+++ b/packages/components/src/components/hero/hero-gradient-ids.ts
@@ -1,0 +1,6 @@
+// There is just one hero component per website, so we don't need to `useId` here.
+const nonce = 'sgz9qg7vvt';
+
+export const GRADIENT_WHITE_ID = `white-${nonce}`;
+export const GRADIENT_WHITE_2_ID = `white-2-${nonce}`;
+export const GRADIENT_GREEN_ID = `green-${nonce}`;

--- a/packages/components/src/components/hero/hero-logo.tsx
+++ b/packages/components/src/components/hero/hero-logo.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, ReactElement } from 'react';
 import { cn } from '../../cn';
-import { GRADIENT_GREEN_ID, GRADIENT_WHITE_2_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
+import { GRADIENT_GREEN_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
 
 export interface HeroLogoProps extends React.HTMLAttributes<HTMLDivElement> {
   children: ReactElement<{

--- a/packages/components/src/components/hero/hero-logo.tsx
+++ b/packages/components/src/components/hero/hero-logo.tsx
@@ -1,0 +1,77 @@
+import { cloneElement, ReactElement } from 'react';
+import { cn } from '../../cn';
+import { GRADIENT_GREEN_ID, GRADIENT_WHITE_2_ID, GRADIENT_WHITE_ID } from './hero-gradient-ids';
+
+export interface HeroLogoProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactElement<{
+    fill?: string;
+    className?: string;
+  }>;
+}
+
+export function HeroLogo({ children, className, ...rest }: HeroLogoProps) {
+  return (
+    <div className={cn('relative', className)} {...rest}>
+      {cloneElement(children, {
+        fill: `url(#${GRADIENT_WHITE_ID})`,
+        className: cn(
+          'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
+          children.props.className,
+        ),
+      })}
+      <LogoBadgeBackground />
+    </div>
+  );
+}
+
+function LogoBadgeBackground() {
+  return (
+    <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="96" height="96" rx="24" fill={`url(#${GRADIENT_GREEN_ID})`} />
+      <rect
+        x="0.5"
+        y="0.5"
+        width="95"
+        height="95"
+        rx="23.5"
+        stroke={`url(#${GRADIENT_WHITE_ID})`}
+      />
+      <path d="M57.0264 32.1652H48.9577L53.8032 27.3197L48.4855 22L43.1658 27.3197L48.0114 32.1652H39.9427C38.9042 32.1652 37.9069 32.5786 37.1721 33.3134L23 47.4855L28.3197 52.8052L45.715 35.4099C47.2452 33.8797 49.7258 33.8797 51.2561 35.4099L68.6513 52.8052L73.971 47.4855L59.797 33.3114C59.0622 32.5767 58.0649 32.1632 57.0264 32.1632V32.1652ZM48.4854 63.3623L43.1665 68.6811L48.4854 74L53.8042 68.6811L48.4854 63.3623ZM39.9446 52.8054H48.4855H48.4894H57.0303C58.0688 52.8054 59.0661 53.2188 59.8008 53.9536L63.89 58.0428L58.5704 63.3625L51.258 56.0501C49.7277 54.5198 47.2472 54.5198 45.7169 56.0501L38.4045 63.3625L33.0848 58.0428L37.174 53.9536C37.9088 53.2188 38.9061 52.8054 39.9446 52.8054Z" />
+      <defs>
+        <linearGradient
+          id={GRADIENT_GREEN_ID}
+          x1="0"
+          y1="0"
+          x2="96"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#3B736A" />
+          <stop offset="1" stopColor="#15433C" />
+        </linearGradient>
+        <linearGradient
+          id={GRADIENT_WHITE_ID}
+          x1="0"
+          y1="0"
+          x2="96"
+          y2="96"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="white" stopOpacity="0.8" />
+          <stop offset="1" stopColor="white" stopOpacity="0.4" />
+        </linearGradient>
+        <linearGradient
+          id={GRADIENT_WHITE_2_ID}
+          x1="1"
+          y1="2"
+          x2="161"
+          y2="171"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="white" stopOpacity="0.1" />
+          <stop offset="1" stopColor="white" stopOpacity="0.5" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/packages/components/src/components/hero/hero-logo.tsx
+++ b/packages/components/src/components/hero/hero-logo.tsx
@@ -37,41 +37,6 @@ function LogoBadgeBackground() {
         stroke={`url(#${GRADIENT_WHITE_ID})`}
       />
       <path d="M57.0264 32.1652H48.9577L53.8032 27.3197L48.4855 22L43.1658 27.3197L48.0114 32.1652H39.9427C38.9042 32.1652 37.9069 32.5786 37.1721 33.3134L23 47.4855L28.3197 52.8052L45.715 35.4099C47.2452 33.8797 49.7258 33.8797 51.2561 35.4099L68.6513 52.8052L73.971 47.4855L59.797 33.3114C59.0622 32.5767 58.0649 32.1632 57.0264 32.1632V32.1652ZM48.4854 63.3623L43.1665 68.6811L48.4854 74L53.8042 68.6811L48.4854 63.3623ZM39.9446 52.8054H48.4855H48.4894H57.0303C58.0688 52.8054 59.0661 53.2188 59.8008 53.9536L63.89 58.0428L58.5704 63.3625L51.258 56.0501C49.7277 54.5198 47.2472 54.5198 45.7169 56.0501L38.4045 63.3625L33.0848 58.0428L37.174 53.9536C37.9088 53.2188 38.9061 52.8054 39.9446 52.8054Z" />
-      <defs>
-        <linearGradient
-          id={GRADIENT_GREEN_ID}
-          x1="0"
-          y1="0"
-          x2="96"
-          y2="96"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="#3B736A" />
-          <stop offset="1" stopColor="#15433C" />
-        </linearGradient>
-        <linearGradient
-          id={GRADIENT_WHITE_ID}
-          x1="0"
-          y1="0"
-          x2="96"
-          y2="96"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="white" stopOpacity="0.8" />
-          <stop offset="1" stopColor="white" stopOpacity="0.4" />
-        </linearGradient>
-        <linearGradient
-          id={GRADIENT_WHITE_2_ID}
-          x1="1"
-          y1="2"
-          x2="161"
-          y2="171"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="white" stopOpacity="0.1" />
-          <stop offset="1" stopColor="white" stopOpacity="0.5" />
-        </linearGradient>
-      </defs>
     </svg>
   );
 }

--- a/packages/components/src/components/hero/index.stories.tsx
+++ b/packages/components/src/components/hero/index.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { hiveThemeDecorator } from '../../../../../.storybook/hive-theme-decorator';
 import { ModulesLogo } from '../../logos';
 import { CallToAction } from '../call-to-action';
-import { Hero } from './index';
+import { Hero, HeroDecorationFromLogo, HeroLogo } from './index';
 
 export default {
   title: 'Hive/Hero',
@@ -20,12 +20,12 @@ export default {
     checkmarks: {
       name: 'Checkmarks text',
     },
-    top: {
-      logo: <ModulesLogo />,
-    },
     text: {
       name: 'Hero text',
     },
+  },
+  parameters: {
+    padding: true,
   },
 } satisfies Meta<ComponentProps<typeof Hero>>;
 
@@ -33,9 +33,11 @@ export const Default: StoryObj<ComponentProps<typeof Hero>> = {
   args: {
     heading: 'Enterprise Grade Tooling for Your GraphQL Server',
     text: 'GraphQL Modules is a toolset of libraries and guidelines dedicated to create reusable, maintainable, testable and extendable modules out of your GraphQL server.',
-    top: {
-      logo: <ModulesLogo />,
-    },
+    top: (
+      <HeroLogo>
+        <ModulesLogo />
+      </HeroLogo>
+    ),
     checkmarks: ['Fully open source', 'No vendor lock'],
     children: (
       <>
@@ -49,6 +51,7 @@ export const Default: StoryObj<ComponentProps<typeof Hero>> = {
           <GitHubIcon className="size-6" />
           GitHub
         </CallToAction>
+        <HeroDecorationFromLogo logo={<ModulesLogo />} />
       </>
     ),
   },

--- a/packages/components/src/components/hero/index.tsx
+++ b/packages/components/src/components/hero/index.tsx
@@ -1,104 +1,30 @@
-import { cloneElement, FC, ReactElement, ReactNode, useId } from 'react';
+import { FC, ReactNode } from 'react';
 import { cn } from '../../cn';
 import { Heading } from '../heading';
 import { CheckIcon } from '../icons';
+import { HeroGradientDefs } from './hero-gradient-defs';
+
+export { HeroLogo } from './hero-logo';
+export { HeroDecorationFromLogo } from './hero-decoration-from-logo';
 
 export interface HeroProps {
   className?: string;
   heading: string;
   text: string;
   checkmarks: string[];
-  top?:
-    | {
-        logo: ReactElement<{ className?: string; fill?: string }>;
-      }
-    | {
-        children: ReactNode;
-      };
   children?: ReactNode;
+  top?: ReactNode;
 }
 
 export const Hero: FC<HeroProps> = props => {
-  const gradientWhiteId = useId();
-  const gradientWhiteId2 = useId();
-  const greenBgId = useId();
-
   return (
     <div
       className={cn(
-        'relative isolate mx-4 flex max-w-[90rem] flex-col items-center justify-center gap-6 overflow-hidden rounded-3xl bg-blue-400 px-4 py-6 max-sm:mt-2 sm:py-12 md:mx-6 md:gap-8 lg:py-24',
+        'relative isolate flex max-w-[90rem] flex-col items-center justify-center gap-6 overflow-hidden rounded-3xl bg-blue-400 px-4 py-6 max-sm:mt-2 sm:py-12 md:gap-8 lg:py-24',
         props.className,
       )}
     >
-      <div className="relative">
-        {props.top &&
-          ('logo' in props.top ? (
-            <>
-              {cloneElement(props.top.logo, {
-                fill: `url(#${gradientWhiteId})`,
-                className: cn(
-                  'absolute inset-1/2 size-1/2 -translate-x-1/2 -translate-y-1/2',
-                  props.top.logo.props.className,
-                ),
-              })}
-              <svg
-                width="96"
-                height="96"
-                viewBox="0 0 96 96"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect width="96" height="96" rx="24" fill={`url(#${greenBgId})`} />
-                <rect
-                  x="0.5"
-                  y="0.5"
-                  width="95"
-                  height="95"
-                  rx="23.5"
-                  stroke={`url(#${gradientWhiteId})`}
-                />
-                <path d="M57.0264 32.1652H48.9577L53.8032 27.3197L48.4855 22L43.1658 27.3197L48.0114 32.1652H39.9427C38.9042 32.1652 37.9069 32.5786 37.1721 33.3134L23 47.4855L28.3197 52.8052L45.715 35.4099C47.2452 33.8797 49.7258 33.8797 51.2561 35.4099L68.6513 52.8052L73.971 47.4855L59.797 33.3114C59.0622 32.5767 58.0649 32.1632 57.0264 32.1632V32.1652ZM48.4854 63.3623L43.1665 68.6811L48.4854 74L53.8042 68.6811L48.4854 63.3623ZM39.9446 52.8054H48.4855H48.4894H57.0303C58.0688 52.8054 59.0661 53.2188 59.8008 53.9536L63.89 58.0428L58.5704 63.3625L51.258 56.0501C49.7277 54.5198 47.2472 54.5198 45.7169 56.0501L38.4045 63.3625L33.0848 58.0428L37.174 53.9536C37.9088 53.2188 38.9061 52.8054 39.9446 52.8054Z" />
-                <defs>
-                  <linearGradient
-                    id={greenBgId}
-                    x1="0"
-                    y1="0"
-                    x2="96"
-                    y2="96"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="#3B736A" />
-                    <stop offset="1" stopColor="#15433C" />
-                  </linearGradient>
-                  <linearGradient
-                    id={gradientWhiteId}
-                    x1="0"
-                    y1="0"
-                    x2="96"
-                    y2="96"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="white" stopOpacity="0.8" />
-                    <stop offset="1" stopColor="white" stopOpacity="0.4" />
-                  </linearGradient>
-                  <linearGradient
-                    id={gradientWhiteId2}
-                    x1="1"
-                    y1="2"
-                    x2="161"
-                    y2="171"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop stopColor="white" stopOpacity="0.1" />
-                    <stop offset="1" stopColor="white" stopOpacity="0.5" />
-                  </linearGradient>
-                </defs>
-              </svg>
-            </>
-          ) : (
-            props.top.children
-          ))}
-      </div>
+      {props.top}
       <Heading as="h1" size="xl" className="mx-auto max-w-3xl text-balance text-center">
         {props.heading}
       </Heading>
@@ -116,6 +42,7 @@ export const Hero: FC<HeroProps> = props => {
       <div className="flex w-full justify-center gap-2 px-0.5 max-sm:flex-col sm:gap-4">
         {props.children}
       </div>
+      <HeroGradientDefs />
     </div>
   );
 };


### PR DESCRIPTION
After chatting with @saihaj, we discovered a best-of-both worlds API with Radix-style small components responsible for one thing which allows building out all the currently used hero sections. I hope it's a nice compromise between #2004 and #2005.

```tsx
<Hero
  heading="Enterprise Grade Tooling for Your GraphQL Server"
  text="GraphQL Modules is a toolset of libraries and guidelines dedicated to create reusable, maintainable, testable and extendable modules out of your GraphQL server."
  top={
    <HeroLogo> {/* wraps the icon in the green badge */}
      <ModulesLogo />
    </HeroLogo>
  }
  checkmarks={["Fully open source", "No vendor lock-in"]}
>
  <CallToAction variant="primary-inverted" href="/docs">
    Get started
  </CallToAction>
  <CallToAction variant="secondary-inverted" href="/changelog">
    Changelog
  </CallToAction>
  <CallToAction
    variant="tertiary"
    href="https://github.com/Urigo/graphql-modules"
  >
    <GitHubIcon className="size-6" />
    GitHub
  </CallToAction>
  {/* creates small logo on the left, big logo on the right decoration like for GraphQL Modules website */}
  <HeroDecorationFromLogo logo={<ModulesLogo />} />
</Hero>;

```