### PR TITLE
Keep `.firefox-highlight-fix` className on the HighlightDecoration

### DIFF
--- a/.changeset/curly-islands-drive.md
+++ b/.changeset/curly-islands-drive.md
@@ -1,0 +1,5 @@
+---
+"@theguild/components": patch
+---
+
+Keep `.firefox-highlight-fix` className on the HighlightDecoration

--- a/packages/components/src/components/decorations/index.tsx
+++ b/packages/components/src/components/decorations/index.tsx
@@ -1,8 +1,8 @@
 import { cn } from '../../cn';
+import { ReactComponent as HighlightDecorationSvg } from './highlight-decoration.svg';
 
 export { ReactComponent as ArchDecoration } from './arch-decoration.svg';
 export { ReactComponent as ArchDecorationGradientDefs } from './arch-decoration-gradient-defs.svg';
-export { ReactComponent as HighlightDecoration } from './highlight-decoration.svg';
 export { ReactComponent as LargeHiveIconDecoration } from './large-hive-icon-decoration.svg';
 
 /**
@@ -16,3 +16,9 @@ export function DecorationIsolation(props: React.HTMLAttributes<HTMLDivElement>)
     />
   );
 }
+
+// Components created from .svg import don't preserve className
+export const HighlightDecoration = (props: React.SVGProps<SVGSVGElement>) => (
+  // eslint-disable-next-line tailwindcss/no-custom-classname
+  <HighlightDecorationSvg {...props} className={cn(props.className, 'firefox-highlight-fix')} />
+);


### PR DESCRIPTION
We need screenshot tests.

The light-noodle bug in Firefox reappeared after a past refactor.
This fixes it.

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/2934c5ce-0af9-4f3e-9e13-5fa1dd4025af" />
