### PR TITLE
Run deploy script instead of builtin pnpm deploy

### DIFF
--- a/.github/workflows/cloudflare-workers.yaml
+++ b/.github/workflows/cloudflare-workers.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Deploy
         working-directory: ./packages/og-image
-        run: pnpm deploy
+        run: pnpm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
I don't know if OG Image service _should_ be deployed, but it kinda annoyed me to have a red CI all the time, because I was afraid I broke it. 

It's breaking now because `pnpm deploy` requires an argument (a directory).

https://pnpm.io/cli/deploy

Instead, we wanna call `pnpm run` with an argument `deploy` (a name of our script).

This `"run"` was _refactored_ out about 2 months ago.