### PR TITLE
Gateway has its own landing now

### DIFF
--- a/packages/components/src/products.tsx
+++ b/packages/components/src/products.tsx
@@ -75,7 +75,7 @@ export const PRODUCTS: Record<ProductType, ProductInfo> = {
     name: 'Hive Gateway',
     title:
       'GraphQL Gateway (Router) for federated GraphQL with Subscriptions support and built-in security features',
-    href: 'https://the-guild.dev/graphql/hive/docs/gateway',
+    href: 'https://the-guild.dev/graphql/hive/gateway',
     logo: HiveGatewayIcon,
     primaryColor: '#ffb21d',
   },


### PR DESCRIPTION
Updated the link, as the Hive Gateway has its own landing page now.

@kamilkisiela thanks for noticing it