### PR TITLE
Hide clear button when input is empty

### DIFF
--- a/.changeset/purple-timers-cry.md
+++ b/.changeset/purple-timers-cry.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+Hide clear button when marketplace input is empty'

--- a/packages/components/src/components/marketplace-search.tsx
+++ b/packages/components/src/components/marketplace-search.tsx
@@ -151,7 +151,8 @@ function MarketplaceSearchInput({
           onClick={() => onChange('')}
           // A builtin clear-button can't be tabbed to. A keyboard user can cmd+A and delete.
           tabIndex={-1}
-          className="flex size-6 items-center justify-center rounded-sm"
+          className="flex size-6 items-center justify-center rounded-sm [input:placeholder-shown+&]:hidden"
+          aria-label="Clear input"
         >
           <CloseIcon className="size-5 text-[--fg-80]" />
         </button>


### PR DESCRIPTION
Thanks for noticing it @saihaj.

We now match the default clear button behaviour.