### PR TITLE
`<CallToAction as="span">` and `type="submit"`

### DIFF
--- a/.changeset/silent-crabs-protect.md
+++ b/.changeset/silent-crabs-protect.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': minor
+---
+
+<CallToAction as="span"> and type="submit"

--- a/packages/components/src/components/call-to-action.stories.tsx
+++ b/packages/components/src/components/call-to-action.stories.tsx
@@ -44,3 +44,23 @@ export const Tertiary: StoryObj<CallToActionProps> = {
     variant: 'tertiary',
   },
 };
+
+export const AsSpan: StoryObj<CallToActionProps> = {
+  args: {
+    as: 'span',
+    children: 'Show More',
+    onClick: () => {
+      // no alert
+    },
+  },
+  decorators: [
+    (Story: React.FC) => (
+      <details>
+        <summary className="list-none pb-4">
+          <Story />
+        </summary>
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.</p>
+      </details>
+    ),
+  ],
+};

--- a/packages/components/src/components/call-to-action.stories.tsx
+++ b/packages/components/src/components/call-to-action.stories.tsx
@@ -82,3 +82,10 @@ export const Link: StoryObj<CallToActionProps> = {
     variant: 'secondary-inverted',
   },
 };
+
+export const Submit: StoryObj<CallToActionProps> = {
+  args: {
+    type: 'submit',
+    children: 'Submit',
+  },
+};

--- a/packages/components/src/components/call-to-action.stories.tsx
+++ b/packages/components/src/components/call-to-action.stories.tsx
@@ -10,6 +10,16 @@ export default {
     children: 'Click me',
     onClick: () => alert('Clicked!'),
   },
+  argTypes: {
+    as: {
+      control: 'select',
+      options: [undefined, 'span', 'div'],
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'primary-inverted', 'secondary', 'secondary-inverted', 'tertiary'],
+    },
+  },
   parameters: {
     padding: true,
   },
@@ -63,4 +73,12 @@ export const AsSpan: StoryObj<CallToActionProps> = {
       </details>
     ),
   ],
+};
+
+export const Link: StoryObj<CallToActionProps> = {
+  args: {
+    href: 'https://the-guild.dev/graphql/hive/ecosystem',
+    children: 'Explore the Ecosystem',
+    variant: 'secondary-inverted',
+  },
 };

--- a/packages/components/src/components/call-to-action.tsx
+++ b/packages/components/src/components/call-to-action.tsx
@@ -35,7 +35,6 @@ export declare namespace CallToActionProps {
     extends BaseProps,
       React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
     href?: never;
-    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   }
 }
 

--- a/packages/components/src/components/call-to-action.tsx
+++ b/packages/components/src/components/call-to-action.tsx
@@ -1,3 +1,4 @@
+import { HTMLAttributes } from 'react';
 import { cn } from '../cn';
 import { Anchor } from './anchor';
 
@@ -29,20 +30,38 @@ export declare namespace CallToActionProps {
 
   export interface AnchorProps extends BaseProps, React.ComponentPropsWithoutRef<typeof Anchor> {
     href: string;
+    as?: never;
   }
 
   export interface ButtonProps
     extends BaseProps,
       React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
     href?: never;
+    as?: never;
+  }
+
+  /**
+   * Use inside `<summary>` or as visual part of bigger interactive element.
+   * Prefer using `href` prop using CallToAction as `<button>` in other cases.
+   */
+  export interface NonInteractiveProps
+    extends BaseProps,
+      React.DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> {
+    href?: never;
+    as: 'span' | 'div';
   }
 }
 
-export type CallToActionProps = CallToActionProps.AnchorProps | CallToActionProps.ButtonProps;
+export type CallToActionProps =
+  | CallToActionProps.AnchorProps
+  | CallToActionProps.ButtonProps
+  | CallToActionProps.NonInteractiveProps;
 
 /**
  * This is called `Button` in Figma in the new Hive brand design system.
- * It's a styled variant of {@link Anchor}.
+ * It's a styled variant of {@link Anchor}. Based on the presence of the
+ * `href` prop or `as` prop, it renders a `button`, `a` or `props.as`
+ * (for non-interactive elements) element.
  *
  * // TODO: Consider renaming it to `Button`.
  */
@@ -53,14 +72,30 @@ export function CallToAction(props: CallToActionProps) {
     props.className,
   );
 
+  const growingBorderBox = (
+    <span className="absolute inset-0 rounded-lg border border-green-800 dark:border-neutral-200" />
+  );
+
   if ('href' in props && typeof props.href === 'string') {
     const { className: _1, variant: _2, children, ...rest } = props;
 
     return (
       <Anchor className={className} {...rest}>
-        <div className="absolute inset-0 rounded-lg border border-green-800 dark:border-neutral-200" />
+        {growingBorderBox}
         {children}
       </Anchor>
+    );
+  }
+
+  if (props.as) {
+    const { className: _1, variant: _2, children, as, ...rest } = props;
+    // for this use case HTMLElement is enough, we don't need to use the more specific HTMLDivElement
+    const Root = as as 'span';
+    return (
+      <Root className={className} {...rest}>
+        {growingBorderBox}
+        {children}
+      </Root>
     );
   }
 
@@ -68,7 +103,7 @@ export function CallToAction(props: CallToActionProps) {
 
   return (
     <button className={className} {...rest}>
-      <div className="absolute inset-0 rounded-lg border border-green-800 dark:border-neutral-200" />
+      {growingBorderBox}
       {children}
     </button>
   );


### PR DESCRIPTION
We have a one-off button on the blog, because the CallToAction was stealing click events and with `pointer-events: none` it wouldn't get hover. I also tried to use `type="submit"` button without `onClick` earlier for the newsletter signup, and it raised a needless type error, so this PR also fixes that.

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/6b2f4151-628d-458b-8075-012818e417d0" />
