### PR TITLE
Add "neutral" severity style to Input

### DIFF
--- a/.changeset/green-rice-brake.md
+++ b/.changeset/green-rice-brake.md
@@ -1,0 +1,5 @@
+---
+'@theguild/components': patch
+---
+
+Add (missing, so this is a patch) neutral severity to Input

--- a/packages/components/src/components/input/index.tsx
+++ b/packages/components/src/components/input/index.tsx
@@ -7,7 +7,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   message?: string;
 }
 
-export function Input({ severity, message, ...props }: InputProps) {
+export function Input({ severity = 'neutral', message, ...props }: InputProps) {
   return (
     <div
       // todo: discuss colors with designers.
@@ -40,6 +40,7 @@ export function Input({ severity, message, ...props }: InputProps) {
           severity === 'critical' && 'bg-critical-dark/10 dark:bg-critical-bright/20',
           severity === 'warning' && 'bg-warning-bright/10',
           severity === 'positive' && 'bg-positive-dark/10',
+          severity === 'neutral' && 'bg-blue-100 dark:bg-neutral-800',
         )}
       >
         {message &&
@@ -47,8 +48,10 @@ export function Input({ severity, message, ...props }: InputProps) {
             <p className="py-0.5 text-sm text-critical-dark dark:text-white">{message}</p>
           ) : severity === 'warning' ? (
             <p className="py-0.5 text-sm text-warning-bright">{message}</p>
-          ) : (
+          ) : severity === 'positive' ? (
             <p className="py-0.5 text-sm text-positive-dark">{message}</p>
+          ) : (
+            <p className="py-0.5 text-sm text-green-800">{message}</p>
           ))}
       </div>
     </div>

--- a/packages/components/src/components/input/input.stories.tsx
+++ b/packages/components/src/components/input/input.stories.tsx
@@ -92,6 +92,15 @@ export const Positive: StoryObj<InputProps> = {
   },
 };
 
+export const Neutral: StoryObj<InputProps> = {
+  args: {
+    severity: 'neutral',
+    message: 'Retrying...',
+    type: 'email',
+    value: 'contact@the-guild.dev',
+  },
+};
+
 export const Disabled: StoryObj<InputProps> = {
   args: {
     disabled: true,

--- a/packages/components/src/types/severity.ts
+++ b/packages/components/src/types/severity.ts
@@ -1,1 +1,1 @@
-export type Severity = 'critical' | 'positive' | 'warning';
+export type Severity = 'critical' | 'positive' | 'warning' | 'neutral';


### PR DESCRIPTION
<img width="549" alt="image" src="https://github.com/user-attachments/assets/62455114-86a0-4ca6-abf9-b43633296868" />

This is gonna make the pending state after an error message a bit nicer. I previously displayed a stale error message, but it wasn't super clear if anything's happening, so this should help.