### PR TITLE
v7 hive navigation better animation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,6 @@
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-import { Configuration } from 'webpack';
-import { StorybookConfig } from '@storybook/nextjs';
+import type { Configuration } from 'webpack';
+import type { StorybookConfig } from '@storybook/nextjs';
 
 export default {
   stories: ['../packages/*/src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],

--- a/packages/components/src/components/hive-navigation/navigation-menu.tsx
+++ b/packages/components/src/components/hive-navigation/navigation-menu.tsx
@@ -92,14 +92,10 @@ export const NavigationMenuContent = forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      'absolute left-0 top-0 w-auto bg-white data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 dark:bg-neutral-900 [&>:first-child]:p-6',
+      'absolute left-0 top-0 w-auto bg-white data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 data-[motion^=to-]:![animation-duration:250ms] data-[motion^=from-]:![animation-duration:450ms] dark:bg-neutral-900 [&>:first-child]:p-6',
       className,
     )}
     {...rest}
-    style={{
-      animationDuration: '0.4s',
-      ...rest.style,
-    }}
   />
 ));
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;


### PR DESCRIPTION
Adjusted navigation menu timing so it doesn't overlap (it feels kinda off in prod now and I didn't have time to polish it before the release) and switched Storybook config imports to import type to avoid bundling type-only modules.

The submenu now animates in slower (matches the window width animation time) but it animates out faster so it doesn't stay on the screen as "ghost ui".
